### PR TITLE
fix: enable python 3.10 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.5] - 2024-10-24
+
+### Change
+
+- Added support for python 3.10
+- Mark python 3.10 as the minimum version.
+
 ## [0.1.4] - 2024-02-17
 
 ### Added

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -10,7 +10,7 @@ project = "Zen Mapper"
 description = "Mapper without the noise"
 copyright = "2023, Ethan Rooke"
 author = "Ethan Rooke"
-release = "0.1.4"
+release = "0.1.5"
 
 
 # -- General configuration ---------------------------------------------------

--- a/flake.nix
+++ b/flake.nix
@@ -52,6 +52,7 @@
       [
         "python312"
         "python311"
+        "python310"
       ]
     );
 

--- a/nix/zen-mapper.nix
+++ b/nix/zen-mapper.nix
@@ -1,10 +1,12 @@
 {
+  lib,
   buildPythonPackage,
   pythonOlder,
   # Build
   hatchling,
   # Dependencies
   numpy,
+  typing-extensions,
   # Check
   pytestCheckHook,
   scikit-learn,
@@ -16,13 +18,15 @@ buildPythonPackage {
   version = "0.1.4";
   pyproject = true;
 
-  disabled = pythonOlder "3.11";
+  disabled = pythonOlder "3.10";
 
   src = ../.;
 
-  propagatedBuildInputs = [
-    numpy
-  ];
+  dependencies =
+    [
+      numpy
+    ]
+    ++ lib.optionals (pythonOlder "3.11") [typing-extensions];
 
   build-system = [
     hatchling

--- a/nix/zen-mapper.nix
+++ b/nix/zen-mapper.nix
@@ -15,7 +15,7 @@
 }:
 buildPythonPackage {
   pname = "zen-mapper";
-  version = "0.1.4";
+  version = "0.1.5";
   pyproject = true;
 
   disabled = pythonOlder "3.10";

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "zen-mapper"
-version = "0.1.4"
+version = "0.1.5"
 description = "Mapper without the noise"
 license = "ISC"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,9 +8,10 @@ authors = [
 ]
 dependencies = [
     "numpy>=1.25.0",
+    'typing-extensions; python_version < "3.11"',
 ]
 readme = "README.md"
-requires-python = ">= 3.11"
+requires-python = ">= 3.10"
 
 [project.urls]
 "Homepage" = "https://github.com/zen-mapper/zen-mapper"

--- a/src/zen_mapper/cover.py
+++ b/src/zen_mapper/cover.py
@@ -1,6 +1,13 @@
 import logging
+import sys
 from collections.abc import Iterator
-from typing import Protocol, Self
+from typing import Protocol
+
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    from typing_extensions import Self
+
 
 import numpy as np
 

--- a/src/zen_mapper/komplex.py
+++ b/src/zen_mapper/komplex.py
@@ -1,7 +1,12 @@
 import logging
+import sys
 from collections.abc import Iterable
 from itertools import chain, combinations, count
-from typing import Self
+
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    from typing_extensions import Self
 
 logger = logging.getLogger("zen_mapper")
 


### PR DESCRIPTION
Adds support for python 3.10 by importing type-extensions if 3.10 or below. This probably also fixes things for 3.9 but networkx is not building on nix for 3.9 so that check is failing to run right now. 