### PR TITLE
Fix docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
 
   workflow_dispatch:
 
@@ -34,10 +37,12 @@ jobs:
             just docs
 
       - name: Upload artifact
+        if: ${{ github.event_name == 'push' }}
         uses: actions/upload-pages-artifact@v2
         with:
           path: ./docs/build/dirhtml
 
       - name: Deploy to GitHub Pages
+        if: ${{ github.event_name == 'push' }}
         id: deployment
         uses: actions/deploy-pages@v3

--- a/flake.nix
+++ b/flake.nix
@@ -60,6 +60,10 @@
       ];
 
       shellHook = ''
+        if [ -z ''${NIX_LD+x} ]
+        then
+          export LD_LIBRARY_PATH="$NIX_LD_LIBRARY_PATH"
+        fi
         uv sync --group docs --group dev
         source .venv/bin/activate
       '';


### PR DESCRIPTION
Something is going wrong on the runner which is causing numpy to not find one
of its libraries. Currently we use
[nix-ld](https://github.com/nix-community/nix-ld) to allow python libraries to
see nix dynamic libraries in the developer environment. However this means the
git ci runner can't see them. In this case we want to use `LD_LIBRARY_PATH`.
Instead of always setting `LD_LIBRARY_PATH` (as this can lead to
[issues](https://github.com/nix-community/nix-ld#why-not-set-ld_library_path-directly-instead-of-nix_ld_library_path))
we instead try to detect the presence of `nix-ld`. If we cannot find `nix-ld`
then we export `LD_LIBRARY_PATH`.

Closes #25.
