### PR TITLE
Decision records

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Build html docs
         run: |
           nix develop --command \
-            just docs
+            just doc-build
 
       - name: Upload artifact
         if: ${{ github.event_name == 'push' }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,10 @@ The general pipeline for getting code added to zen-mapper is as follows:
 
 Before submitting a new feature it is wise to open an issue discussing the
 proposed feature to make sure that there is interest first. Beyond that we can
-hash everything out during the review process.
+hash everything out during the review process. What follows are tips on how to
+develop code for zen-mapper and requirements for getting a change merged. Don't
+worry too much about following these to the letter, that's what the review
+process is for.
 
 ### Developer Environment
 
@@ -34,3 +37,14 @@ running `just` will list all the tasks you can run.
 If you don't use nix, we provide files for using uv to manage your environment.
 Instructions on how to do that can be found
 [here](https://docs.astral.sh/uv/guides/projects/).
+
+### Architectural Design Decisions
+
+If your change includes a design choice which addresses a requirement which is
+architecturally significant a brief description of why your choice was made
+will need to be added to the decision log in `docs/source/decisions`. These
+descriptions should follow the [MADR 4.0.0](https://adr.github.io/madr/) spec.
+There are templates in `docs/source/decisions` for you to use. Do not worry
+about this too much if opening a PR, if one is needed it will be mentioned
+before merging and it will probably encode whatever discussion in the issues or
+pull request led to the decision being made.

--- a/docs/source/decisions/0000-use-madr.md
+++ b/docs/source/decisions/0000-use-madr.md
@@ -1,0 +1,32 @@
+# Use MADR
+
+## Context and Problem Statement
+
+We wish to record important decisions made in this project. How should we do
+that?
+
+## Decision Drivers
+
+* Allow new contributors to easily understand past decisions
+* Avoid vendor/tool lock in
+* Minimize developer overhead
+
+## Considered Options
+
+* [MADR 4.0.0](https://adr.github.io/madr/)
+* [Nygard](https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions.html)
+  template
+* Github issues
+* Project-wide design document
+* No specified format
+
+## Decision Outcome
+
+Chosen option: "[MADR 4.0.0](https://adr.github.io/madr/)" because
+
+- A project-wide design document sounds tiring
+- No specified format leads to blank page syndrome
+- Github issues locks us into a specific vendor
+- Markdown is lightweight and easy to write
+- Using a standard opens us up to the potential for tool re-use
+- Just needed to choose *something*

--- a/docs/source/decisions/index.md
+++ b/docs/source/decisions/index.md
@@ -1,0 +1,12 @@
+# Decision Log
+
+This log lists the architectural decisions for the zen mapper project.
+
+```{toctree}
+:name: adr-toc
+:titlesonly:
+:numbered: 1
+:glob:
+
+*
+```

--- a/docs/source/decisions/templates/complete.md
+++ b/docs/source/decisions/templates/complete.md
@@ -1,0 +1,74 @@
+---
+# These are optional metadata elements. Feel free to remove any of them.
+status: "{proposed | rejected | accepted | deprecated | … | superseded by ADR-0123"
+date: {YYYY-MM-DD when the decision was last updated}
+decision-makers: {list everyone involved in the decision}
+consulted: {list everyone whose opinions are sought (typically subject-matter experts); and with whom there is a two-way communication}
+informed: {list everyone who is kept up-to-date on progress; and with whom there is a one-way communication}
+---
+
+# {short title, representative of solved problem and found solution}
+
+## Context and Problem Statement
+
+{Describe the context and problem statement, e.g., in free form using two to three sentences or in the form of an illustrative story. You may want to articulate the problem in form of a question and add links to collaboration boards or issue management systems.}
+
+<!-- This is an optional element. Feel free to remove. -->
+## Decision Drivers
+
+* {decision driver 1, e.g., a force, facing concern, …}
+* {decision driver 2, e.g., a force, facing concern, …}
+* … <!-- numbers of drivers can vary -->
+
+## Considered Options
+
+* {title of option 1}
+* {title of option 2}
+* {title of option 3}
+* … <!-- numbers of options can vary -->
+
+## Decision Outcome
+
+Chosen option: "{title of option 1}", because {justification. e.g., only option, which meets k.o. criterion decision driver | which resolves force {force} | … | comes out best (see below)}.
+
+<!-- This is an optional element. Feel free to remove. -->
+### Consequences
+
+* Good, because {positive consequence, e.g., improvement of one or more desired qualities, …}
+* Bad, because {negative consequence, e.g., compromising one or more desired qualities, …}
+* … <!-- numbers of consequences can vary -->
+
+<!-- This is an optional element. Feel free to remove. -->
+### Confirmation
+
+{Describe how the implementation / compliance of the ADR can/will be confirmed. Is there any automated or manual fitness function? If so, list it and explain how it is applied. Is the chosen design and its implementation in line with the decision? E.g., a design/code review or a test with a library such as ArchUnit can help validate this. Note that although we classify this element as optional, it is included in many ADRs.}
+
+<!-- This is an optional element. Feel free to remove. -->
+## Pros and Cons of the Options
+
+### {title of option 1}
+
+<!-- This is an optional element. Feel free to remove. -->
+{example | description | pointer to more information | …}
+
+* Good, because {argument a}
+* Good, because {argument b}
+<!-- use "neutral" if the given argument weights neither for good nor bad -->
+* Neutral, because {argument c}
+* Bad, because {argument d}
+* … <!-- numbers of pros and cons can vary -->
+
+### {title of other option}
+
+{example | description | pointer to more information | …}
+
+* Good, because {argument a}
+* Good, because {argument b}
+* Neutral, because {argument c}
+* Bad, because {argument d}
+* …
+
+<!-- This is an optional element. Feel free to remove. -->
+## More Information
+
+{You might want to provide additional evidence/confidence for the decision outcome here and/or document the team agreement on the decision and/or define when/how this decision the decision should be realized and if/when it should be re-visited. Links to other decisions and resources might appear here as well.}

--- a/docs/source/decisions/templates/minimal.md
+++ b/docs/source/decisions/templates/minimal.md
@@ -1,0 +1,12 @@
+# <!-- short title, representative of solved problem and found solution -->
+
+## Context and Problem Statement
+
+
+
+## Considered Options
+
+
+
+## Decision Outcome
+

--- a/justfile
+++ b/justfile
@@ -25,8 +25,12 @@ check check:
 	nix build .#checks.x86_64-linux.{{check}}
 
 # Build the docs
-docs:
+doc-build:
 	cd docs && make dirhtml
+
+# Serve the docs
+doc-serve: doc-build
+	python -m http.server -d docs/build/dirhtml
 
 # Build the package
 build:


### PR DESCRIPTION
This pr initializes a documentation detailing why various architectural
decisions were made.

As zen mapper is a project mostly developed by a slowly revolving group of
academics I believe it is important to record why various decisions were made.
This will allow for future contributors to more easily understand the structure
of the software and why it was done this way. Even if for some decisions the
answer is "we just picked something" this will help them more accurately gauge
where to dedicate their efforts.

I propose that we use the [madr](https://adr.github.io/madr/) standard to do
this as it gives structure to this style of documentation.
