### PR TITLE
build: allow checks to continue despite errors

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -34,6 +34,7 @@ jobs:
     needs: define-matrix
     runs-on: ubuntu-22.04
     strategy:
+      fail-fast: false
       matrix: ${{fromJSON(needs.define-matrix.outputs.matrix)}}
     steps:
       - name: git checkout


### PR DESCRIPTION
Previously if any check defined in the flake failed all the queued
checks were cancelled. These checks are independent of each other, one
failing does not saying anything about the others. By setting
`fail-fast` to false the remaining checks are allowed to run.
