### PR TITLE
Filter empty cover elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The cover protocol previously required being an iterable of numpy arrays.
   This was loosened to allow for iterables of anything which is convertible to
   a numpy array.
+- Empty cover elements are now filtered out to avoid creating empty nodes
 
 ### Fixed
 

--- a/flake.nix
+++ b/flake.nix
@@ -46,6 +46,7 @@
       LC_ALL = "en_US.UTF-8";
 
       buildInputs = [
+        pkgs.pyright
         pkgs.uv
         pkgs.hatch
         pkgs.jq

--- a/src/zen_mapper/__init__.py
+++ b/src/zen_mapper/__init__.py
@@ -64,7 +64,9 @@ def mapper(
 
     cover_elements = map(np.array, cover_scheme(projection))
 
-    for i, element in enumerate(cover_elements):
+    for i, element in enumerate(
+        filter(lambda element: element.size != 0, cover_elements)
+    ):
         logger.info("Clustering cover element %d", i)
         clusters = clusterer(data[element])
         new_nodes = [element[cluster] for cluster in clusters]


### PR DESCRIPTION
Right now empty cover elements are passed to the clustering algorithm resulting
in nodes corresponding to no data. This change filters out the empty cover
elements.

