### PR TITLE
fix: record cluster metadata for empty cover elements

### DIFF
--- a/packages/zen-mapper/CHANGELOG.md
+++ b/packages/zen-mapper/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The clusterer protocol requires passing in the global dataset along with the
   indices to cluster now.
 - The sk_learn adapter now accepts `ArrayLike` objects, not just `ndarray`s
+- The clusterer protocol now allows returning `ArrayLike` objects, not just `ndarray`s
 
 ### Fixed
 

--- a/packages/zen-mapper/CHANGELOG.md
+++ b/packages/zen-mapper/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed a bug where empty nodes could slip into the mapper graph
 - Fixed a bug where mapper tried to cluster empty cover elements
+- Empty cover elements now record `None` as their metadata information
 
 ## [0.3.0] - 2025-06-02
 

--- a/packages/zen-mapper/src/zen_mapper/mapper.py
+++ b/packages/zen-mapper/src/zen_mapper/mapper.py
@@ -56,7 +56,7 @@ def mapper(
     cover_id = list()
     metadata = list()
 
-    cover_elements = map(np.array, cover_scheme(projection))
+    cover_elements = map(np.asarray, cover_scheme(projection))
 
     for i, element in enumerate(cover_elements):
         if len(element) == 0:

--- a/packages/zen-mapper/src/zen_mapper/mapper.py
+++ b/packages/zen-mapper/src/zen_mapper/mapper.py
@@ -62,15 +62,18 @@ def mapper(
         if len(element) == 0:
             logger.info("Cover element %d is empty", i)
             cover_id.append(list())
+            metadata.append(None)
             continue
 
         logger.info("Clustering cover element %d", i)
         clusters, meta = clusterer(data, element)
         logger.info("Found %d clusters", len(clusters))
-        metadata.append(meta)
+
         m = len(nodes)
         n = len(clusters)
         cover_id.append(list(range(m, m + n)))
+        metadata.append(meta)
+
         nodes.extend(element[np.asarray(cluster)] for cluster in clusters)
 
     return MapperResult(

--- a/packages/zen-mapper/src/zen_mapper/mapper.py
+++ b/packages/zen-mapper/src/zen_mapper/mapper.py
@@ -71,7 +71,7 @@ def mapper(
         m = len(nodes)
         n = len(clusters)
         cover_id.append(list(range(m, m + n)))
-        nodes.extend(element[cluster] for cluster in clusters)
+        nodes.extend(element[np.asarray(cluster)] for cluster in clusters)
 
     return MapperResult(
         nodes=nodes,

--- a/packages/zen-mapper/src/zen_mapper/test_cluster.py
+++ b/packages/zen-mapper/src/zen_mapper/test_cluster.py
@@ -1,6 +1,9 @@
 import numpy as np
 from sklearn.cluster import DBSCAN
 
+from zen_mapper import mapper
+from zen_mapper.cover import precomputed_cover
+
 from .adapters import sk_learn
 
 
@@ -11,7 +14,7 @@ def test_sk_learn():
     db = DBSCAN(eps=0.1, min_samples=2)
     clusterer = sk_learn(db)
     clusters, _ = clusterer(data, np.arange(N_SAMPLES))
-    clusters = list(clusters)
+    clusters = list(map(np.asarray, clusters))
     assert len(clusters) == 1
     assert len(clusters[0]) == len(data)
 
@@ -20,6 +23,23 @@ def test_empty_dtype():
     db = DBSCAN(eps=0.1, min_samples=2)
     clusterer = sk_learn(db)
     clusters, _ = clusterer(np.array([]), np.arange(0))
-    clusters = list(clusters)
+    clusters = list(map(np.asarray, clusters))
     for cluster in clusters:
         assert cluster.dtype == "int64"
+
+
+def test_non_array_cluster():
+    """Clusterers should be able to return array like objects"""
+
+    def _trivial_cluster(data, elements):
+        return [range(len(elements))], None
+
+    N_SAMPLES = 100
+    data = np.empty(N_SAMPLES)
+    mapper(
+        data=data,
+        projection=data,
+        cover_scheme=precomputed_cover([np.arange(N_SAMPLES)]),
+        clusterer=_trivial_cluster,
+        dim=0,
+    )

--- a/packages/zen-mapper/src/zen_mapper/types.py
+++ b/packages/zen-mapper/src/zen_mapper/types.py
@@ -333,7 +333,7 @@ class Clusterer(Protocol[H, M]):
         self,
         data: H,
         elements: np.ndarray,
-    ) -> tuple[Collection[np.ndarray], M]:
+    ) -> tuple[Collection[npt.ArrayLike], M]:
         """Partition a subset of the dataset into disjoint groups.
 
         Parameters
@@ -346,9 +346,10 @@ class Clusterer(Protocol[H, M]):
 
         Returns
         -------
-        partition : Collection[np.ndarray]
-            A Collection of NumPy arrays. Each array contains indices into
-            `elements`. The collection must form a partition of `elements`.
+        partition : Collection[npt.ArrayLike]
+            A Collection of NumPy array-like things. Each array contains
+            indices into `elements`. The collection must form a partition of
+            `elements`.
         metadata : M
             Associated metadata produced by the clustering process. Returns
             None if no meaningful metadata is generated.

--- a/packages/zen-mapper/src/zen_mapper/types.py
+++ b/packages/zen-mapper/src/zen_mapper/types.py
@@ -392,15 +392,14 @@ class MapperResult(Generic[M]):
         Each inner list contains the indices of the original data points that
         fall into a specific cover element. This provides a mapping from the
         original dataset to the cover.
-    cluster_metadata : list[M]
-        A list of metadata objects, where each object corresponds to a
-        cluster (node) in the Mapper graph. The type `M` is generic,
-        allowing for flexible storage of any additional information
-        relevant to each cluster, such as cluster statistics, labels,
-        or other derived properties.
+    cluster_metadata : list[M | None]
+        A list of clustering metadata objects. The object `cluster_metadata[i]`
+        corresponds to whatever metadata the clusterer produced on cover
+        element `i`. If cover element `i` was empty this will
+        `cluster_metadata[i]` is `None`.
     """
 
     nodes: list[np.ndarray]
     nerve: Komplex
     cover: list[list[int]]
-    cluster_metadata: list[M]
+    cluster_metadata: list[M | None]


### PR DESCRIPTION
Empty cover elements now record `None` as their metadata information