### PR TITLE
remove covering scheme from api

### DIFF
--- a/packages/kaiju-mapper/src/kaiju_mapper/__init__.py
+++ b/packages/kaiju-mapper/src/kaiju_mapper/__init__.py
@@ -1,5 +1,5 @@
 from zen_mapper import mapper
 
-from kaiju_mapper.gmapper import GMapperCoverScheme
+from kaiju_mapper.gmapper import g_mapper_cover
 
-__all__ = ("GMapperCoverScheme", "mapper")
+__all__ = ("g_mapper_cover", "mapper")

--- a/packages/kaiju-mapper/src/kaiju_mapper/gmapper.py
+++ b/packages/kaiju-mapper/src/kaiju_mapper/gmapper.py
@@ -10,7 +10,7 @@ from sklearn.mixture import GaussianMixture
 
 from kaiju_mapper.types import Seed
 
-__all__ = ("GMapperCoverScheme", "Interval")
+__all__ = ("g_mapper_cover", "Interval")
 
 
 _logger = logging.getLogger("kaiju_mapper")
@@ -33,8 +33,14 @@ class Interval:
     """Indices of the covered dataset which lie in this interval"""
 
 
-@dataclass
-class GMapperCoverScheme:
+def g_mapper_cover(
+    data: np.ndarray,
+    iterations: int,
+    max_intervals: int,
+    ad_threshold: float,
+    g_overlap: float,
+    seed: Seed | None = None,
+):
     """Adaptive cover via Gaussian mixture models
     introduced in Alvarado, et al. [#gmapper]_, G-Mapper is a scheme for
     producing a cover for Mapper inspired by the G-means clustering algorithm
@@ -49,65 +55,45 @@ class GMapperCoverScheme:
         Percival, and E. Purvine,  "G-mapper: Learning a cover in the mapper
         construction" 2025.
     .. [#gmeans] G. Hamerly, C. Elkan, "Learning the k in k-means" 2003.
+
+    Args:
+        iterations: The max number of attempted splits
+        max_intervals: The max number of intervals
+        ad_threshold: The maximum alowed Anderson-Darling score for an interval
+        g_overlap: How much split intervals should overlap
+        intervals: After fitting this contains the learned intervals
+        seed: Random source for the gaussian mixture model algorithm
     """
+    if iterations < 1:
+        raise ValueError(f"iterations must be > 0, got {iterations}")
 
-    iterations: int
-    """The max number of attempted splits"""
-    max_intervals: int
-    """The max number of intervals"""
-    ad_threshold: float
-    """The maximum alowed Anderson-Darling score for an interval"""
-    g_overlap: float
-    """How much split intervals should overlap"""
-    intervals: list[Interval]
-    """After fitting this contains the learned intervals"""
-    rng: np.random.Generator
-    """Random source for the gaussian mixture model algorithm"""
+    if max_intervals < 1:
+        raise ValueError(f"max_intervals must be > 0, got {max_intervals}")
 
-    def __init__(
-        self,
-        iterations: int,
-        max_intervals: int,
-        ad_threshold: float,
-        g_overlap: float,
-        seed: Seed | None = None,
-    ):
-        if iterations < 1:
-            raise ValueError(f"iterations must be > 0, got {iterations}")
+    if ad_threshold <= 0:
+        raise ValueError(f"ad_threshold must be > 0, got {ad_threshold}")
 
-        if max_intervals < 1:
-            raise ValueError(f"max_intervals must be > 0, got {max_intervals}")
+    if g_overlap <= 0 or g_overlap >= 1:
+        raise ValueError(f"g_overlap must be in the range (0,1), got {g_overlap}")
 
-        if ad_threshold <= 0:
-            raise ValueError(f"ad_threshold must be > 0, got {ad_threshold}")
-
-        if g_overlap <= 0 or g_overlap >= 1:
-            raise ValueError(f"g_overlap must be in the range (0,1), got {g_overlap}")
-
-        self.iterations = iterations
-        self.max_intervals = max_intervals
-        self.ad_threshold = ad_threshold
-        self.g_overlap = g_overlap
-        self.rng = np.random.default_rng(seed)
-        self.intervals = list()
-
-    def __call__(self, data: np.ndarray):
-        """Compute the cover"""
-        if data.squeeze().ndim > 1:
-            raise ValueError(
-                f"Data must be one dimensional, got matrix with shape {data.shape}"
-            )
-        self.intervals = _bfs(
-            lens=data.flatten(),
-            iterations=self.iterations,
-            max_intervals=self.max_intervals,
-            ad_threshold=self.ad_threshold,
-            g_overlap=self.g_overlap,
-            random_state=int(self.rng.integers(0, 4294967295, endpoint=True)),
-            # sklearn does not accept the new numpy generators, only ints
+    if data.squeeze().ndim > 1:
+        raise ValueError(
+            f"Data must be one dimensional, got matrix with shape {data.shape}"
         )
 
-        return [interval.members for interval in self.intervals]
+    rng = np.random.default_rng(seed)
+
+    intervals = _bfs(
+        lens=data.flatten(),
+        iterations=iterations,
+        max_intervals=max_intervals,
+        ad_threshold=ad_threshold,
+        g_overlap=g_overlap,
+        random_state=int(rng.integers(0, 4294967295, endpoint=True)),
+        # sklearn does not accept the new numpy generators, only ints
+    )
+
+    return [interval.members for interval in intervals]
 
 
 def _ad_test(data: np.ndarray) -> float:

--- a/packages/kaiju-mapper/tests/test_gmapper.py
+++ b/packages/kaiju-mapper/tests/test_gmapper.py
@@ -6,7 +6,7 @@ from hypothesis import given
 from hypothesis import strategies as st
 from hypothesis.extra.numpy import arrays
 
-from kaiju_mapper.gmapper import GMapperCoverScheme, _split, _make_interval
+from kaiju_mapper.gmapper import _make_interval, _split, g_mapper_cover
 
 
 # The sklearn GaussianMixture fitting procedure generates a lot of warnings on
@@ -85,29 +85,25 @@ def test_split_clamping(
     )
 
 
-@st.composite
-def cover_scheme(draw):
-    return GMapperCoverScheme(
-        iterations=draw(st.integers(min_value=1)),
-        max_intervals=draw(st.integers(min_value=1, max_value=1_000)),
-        g_overlap=draw(
-            st.floats(
-                min_value=0,
-                max_value=1,
-                allow_nan=False,
-                exclude_min=True,
-                exclude_max=True,
-            )
+cover_scheme = st.fixed_dictionaries(
+    {
+        "iterations": st.integers(min_value=1),
+        "max_intervals": st.integers(min_value=1, max_value=1_000),
+        "g_overlap": st.floats(
+            min_value=0,
+            max_value=1,
+            allow_nan=False,
+            exclude_min=True,
+            exclude_max=True,
         ),
-        ad_threshold=draw(
-            st.floats(
-                min_value=0,
-                max_value=250,
-                allow_nan=False,
-                exclude_min=True,
-            )
+        "ad_threshold": st.floats(
+            min_value=0,
+            max_value=250,
+            allow_nan=False,
+            exclude_min=True,
         ),
-    )
+    }
+)
 
 
 # The sklearn GaussianMixture fitting procedure generates a lot of warnings on
@@ -115,16 +111,16 @@ def cover_scheme(draw):
 # in our test suite.
 @pytest.mark.filterwarnings("ignore::RuntimeWarning")
 @given(
-    cover_scheme(),
+    cover_scheme,
     arrays(
         dtype=float,
         shape=st.integers(min_value=1, max_value=10_000),
         elements=st.floats(allow_nan=False, allow_infinity=False),
     ),
 )
-def test_max_intervals(cover_scheme: GMapperCoverScheme, data: np.ndarray):
-    cover = cover_scheme(data)
-    assert len(cover) <= cover_scheme.max_intervals
+def test_max_intervals(cover_scheme: dict, data: np.ndarray):
+    cover = g_mapper_cover(data=data, **cover_scheme)
+    assert len(cover) <= cover_scheme["max_intervals"]
 
 
 # The sklearn GaussianMixture fitting procedure generates a lot of warnings on
@@ -132,14 +128,14 @@ def test_max_intervals(cover_scheme: GMapperCoverScheme, data: np.ndarray):
 # in our test suite.
 @pytest.mark.filterwarnings("ignore::RuntimeWarning")
 @given(
-    cover_scheme(),
+    cover_scheme,
     arrays(
         dtype=float,
         shape=st.integers(min_value=1, max_value=10_000),
         elements=st.floats(allow_nan=False, allow_infinity=False),
     ),
 )
-def test_coverage(cover_scheme: GMapperCoverScheme, data: np.ndarray):
-    cover = cover_scheme(data)
+def test_coverage(cover_scheme: dict, data: np.ndarray):
+    cover = g_mapper_cover(data=data, **cover_scheme)
     covered_points = set(chain(*cover))
     assert covered_points == set(np.arange(len(data)))

--- a/packages/zen-mapper/CHANGELOG.md
+++ b/packages/zen-mapper/CHANGELOG.md
@@ -15,10 +15,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Change
 
-- The clusterer protocol requires passing in the global dataset along with the
-  indices to cluster now.
-- The sk_learn adapter now accepts `ArrayLike` objects, not just `ndarray`s
-- The clusterer protocol now allows returning `ArrayLike` objects, not just `ndarray`s
+- **Breaking:** Mapper now requires a concrete cover be supplied instead of a
+  covering scheme
+- **Breaking:** The clusterer protocol now requires passing in the global
+  dataset along with the indices to cluster.
+- The `sk_learn adapter` now accepts `ArrayLike` objects, not just `ndarray`s
+- The `clusterer` protocol now allows returning `ArrayLike` objects, not just `ndarray`s
+
+### Removed
+
+- **Breaking:** Removed the `CoverScheme` protocol
 
 ### Fixed
 

--- a/packages/zen-mapper/docs/source/conf.py
+++ b/packages/zen-mapper/docs/source/conf.py
@@ -49,6 +49,11 @@ intersphinx_mapping = {
     "networkx": ("https://networkx.org/documentation/stable/", None),
 }
 
+# Resolve type aliases to the alias themselves, not the aliased value
+autodoc_type_aliases = {
+    "Cover": ":type:`~zen_mapper.types.Cover`",
+}
+
 add_module_names = False
 
 typehints_defaults = "comma"

--- a/packages/zen-mapper/docs/source/decisions/0003-allow-user-supplied-covers.md
+++ b/packages/zen-mapper/docs/source/decisions/0003-allow-user-supplied-covers.md
@@ -1,0 +1,26 @@
+---
+status: "accepted"
+date: "2026-06-21"
+---
+# Allow user supplied covers
+
+## Context and Problem Statement
+
+The mapper algorithm needs a cover of the high dimensional data in order to
+function. Should the end user be able to define their own covers?
+
+
+## Decision Drivers
+
+- Flexibility, zen mapper should enable as many use cases as possible
+- Extensibility, zen mapper should be open to extensions
+
+## Considered Options
+
+- Enable user supplied covers
+- Hardcode the most common covers
+
+## Decision Outcome
+
+"Enable user supplied covers", because this is the only thing which facilitates
+extensibility.

--- a/packages/zen-mapper/docs/source/decisions/0004-use-an-explicit-cover.md
+++ b/packages/zen-mapper/docs/source/decisions/0004-use-an-explicit-cover.md
@@ -1,0 +1,95 @@
+---
+status: "accepted"
+date: "2026-06-21"
+---
+# Use an explicit cover
+
+## Context and Problem Statement
+
+The mapper algorithm needs a cover of the high dimensional data in order to
+function. The end user should be able to supply this. There are two orthogonal
+questions that need answering.
+
+1. Should the user provide the raw cover or a method for producing a cover?
+1. How should the data of a cover be encoded?
+
+This seeks to address the first question.
+
+## Decision Drivers
+
+- Minimal overhead for people implementing new covers
+- Flexibility, as many use cases as possible should be enabled
+- Type safety, python type checkers should be able to tell what is going on
+
+## Considered Options
+
+- Supply a method for computing the cover
+- Supply a realized cover
+
+## Decision Outcome
+
+Chosen option: "Supply a realized cover", because supplying a method for
+computing the cover adds no benefits and just complicates the interface.
+
+There was a concern that asking the user to supply a realized cover might
+increase the overhead on their side. In practice this seems to be a non-issue.
+Regardless the user is going to request a cover from a function, the only
+question is what it requires and what it returns. Supplying a cover method
+looks like this:
+
+```py
+# Supply a method for computing the cover
+cover_scheme = Width_Balanced_Cover(num_bins=10, percent_overlap=0.2)
+result = mapper( cover = cover_scheme, ...)
+```
+
+supplying a realized cover looks like this:
+
+```py
+# Supply a cover
+cover = width_balanced_cover(projection, num_bins=10, percent_overlap=0.2)
+result = mapper(cover = cover, ...)
+```
+
+The amount of work from the user is the same in both cases. The only potential
+issue would be purely conceptual. The second method requires that you supply
+the projection at the time of specifying the cover. We think this is a fine
+amount of understanding to require of our users.
+
+Moreover with the current method it is not immediately obvious how one
+introspects the computed cover. With the "supply a cover" method this is can be
+made much more clear; any function which fits a cover is responsible for
+returning the metadata as well. This results in code which looks like the
+following:
+
+```py
+# Supply a cover
+cover, metadata = width_balanced_cover(projection, num_bins=10, percent_overlap=0.2)
+result = mapper(cover = cover, ...)
+```
+
+Our interface decision here does not put any requirement that there be a
+metadata object returned nor makes any requirement of its form. This could lead
+to issues down the road if many cover schemes are implemented and they diverge
+on this pattern. This is a bridge we can cross if it comes.
+
+## Pros and Cons of the Options
+
+### Supply a method for computing the cover
+
+- Good, because we already have this implemented
+- Good, because it lines up with how users conceptualize mapper
+- Bad, because it increases the overhead of implementing a new cover
+- Bad, because it obscures how to interact with covering metadata
+
+### Supply a realized cover
+
+- Good, because it minimizes overhead of implementing a new cover
+- Good, because it simplifies the implementation of the mapper algorithm
+- Good, because it makes type hinting easier
+- Bad, because it maybe adds conceptual overhead to the user
+- Bad, because it maybe does not line up with how users conceptualize mapper
+
+## More Information
+
+[ADR-0003](./0003-allow-user-supplied-covers.md) reasons on allowing user supplied covers

--- a/packages/zen-mapper/docs/source/decisions/0005-use-numpy-array-to-encode-cover-elements.md
+++ b/packages/zen-mapper/docs/source/decisions/0005-use-numpy-array-to-encode-cover-elements.md
@@ -1,0 +1,37 @@
+---
+status: "accepted"
+date: "2026-06-21"
+---
+# Use numpy array to encode cover elements
+
+## Context and Problem Statement
+
+The mapper algorithm needs a cover of the high dimensional data in order to
+function. We need a way to represent cover elements.
+
+## Decision Drivers
+
+- Minimal overhead for people implementing new covers
+
+## Considered Options
+
+- Use a numpy array with indices into the original data
+
+## Decision Outcome
+
+Chosen option: "Use a numpy array with indices into the original data", because
+this is the most obvious solution and it is unclear the rest of the mapper
+pipeline scales enough for this to be the bottleneck.
+
+### Consequences
+
+- Good, because easy to implement.
+- Good, because easy to work with.
+- Bad, because invalid states are representable (`[1, 1, 2]` is not a set).
+- Bad, because it requires the data to fit in memory. If this is a concern it
+  is unclear that zen mapper is the right tool for the job.
+
+## More Information
+
+- [ADR-0003](./0003-allow-user-supplied-covers.md) reasons on allowing user supplied covers
+- [ADR-0004](./0004-use-an-explicit-cover.md) reasons to supply a cover instead of a scheme

--- a/packages/zen-mapper/docs/source/decisions/0006-encode-covers-as-iterable.md
+++ b/packages/zen-mapper/docs/source/decisions/0006-encode-covers-as-iterable.md
@@ -1,0 +1,79 @@
+---
+status: "accepted"
+date: "2026-06-21"
+---
+# Encode covers as iterables
+
+## Context and Problem Statement
+
+The mapper algorithm needs a cover of the high dimensional data in order to
+function. The end user should be able to supply this. There are two orthogonal
+questions that need answering.
+
+1. Should the user provide the raw cover or a method for producing a cover
+1. How should the data of a cover be encoded
+
+This adr seeks to address the second question. We will take it as a given for
+now that we represent cover elements as numpy arrays of indices into the
+original data. This can be examined in the future but it is how we have
+implemented thing thus far.
+
+## Decision Drivers
+
+- Minimal overhead for people implementing new covers
+- Flexibility, as many use cases as possible should be enabled
+- Extensibility, in the future we should be able to add functionality without
+  breaking old implementations
+- Type safety, python type checkers should be able to tell what is going on
+
+## Considered Options
+
+- An iterable of cover elements
+- An iterable of id, cover element pairs
+- A mapping of cover elements
+- Some custom base class
+
+## Decision Outcome
+
+"An iterable of cover elements", because it is the simplest of the proposed
+options to implement and does not seem to hamper us in anyway.
+
+## Pros and Cons of the Options
+
+### An iterable of cover elements
+
+- Good, because it requires very little of the author
+- Good, because it gives us everything we actually need
+- Good, because it trivially enables streaming covers
+- Bad, because it does not support random access
+- Bad, because it forces the cover elements to be keyed by integers
+
+### An iterable of id, cover element pairs
+
+- Good, because it gives us everything we actually need
+- Good, because it trivially enables streaming covers
+- Good, because it enables the cover elements to be keyed by arbitrary elements
+- Bad, because implementing this interface will require boilerplate in most
+  cases just to enable features in rare cases
+- Bad, because it does not support random access
+
+### A mapping of cover elements
+
+- Good, because it allows arbitrary keying of cover elements
+- Bad, because it requires more work on the implementer, there are not that
+  many built in map types
+- Bad, because it complicates streaming covers. There are no built in lazy map
+  types.
+
+### Some custom base class
+
+- Good, because it enables us to enforce our contract strictly
+- Bad, because it requires the implementer to extend our class instead of
+  reusing types that already exist
+
+## More Information
+
+- [ADR-0003](./0003-allow-user-supplied-covers.md) reasons on allowing user supplied covers
+- [ADR-0004](./0004-use-an-explicit-cover.md) reasons to supply a cover instead of a scheme
+- [ADR-0005](./0005-use-numpy-array-to-encode-cover-elements.md) reasons to
+  encode cover elements as numpy arrays

--- a/packages/zen-mapper/examples/basic.py
+++ b/packages/zen-mapper/examples/basic.py
@@ -28,8 +28,11 @@ plt.show()
 # =================
 import zen_mapper as zm
 
-cover_scheme = zm.Width_Balanced_Cover(n_elements=3, percent_overlap=0.4)
-cover = cover_scheme(projection)
+cover, _ = zm.width_balanced_cover(
+    n_elements=3,
+    percent_overlap=0.4,
+    data=projection,
+)
 
 
 for i, c in enumerate(cover):
@@ -73,8 +76,7 @@ clusterer = zm.sk_learn(sk)
 
 result = zm.mapper(
     data=data,
-    projection=projection,
-    cover_scheme=cover_scheme,
+    cover=cover,
     clusterer=clusterer,
     dim=1,
 )

--- a/packages/zen-mapper/examples/cluster_meta.py
+++ b/packages/zen-mapper/examples/cluster_meta.py
@@ -27,8 +27,11 @@ plt.show()
 # =================
 import zen_mapper as zm
 
-cover_scheme = zm.Width_Balanced_Cover(n_elements=3, percent_overlap=0.4)
-cover = cover_scheme(projection)
+cover, _ = zm.width_balanced_cover(
+    n_elements=3,
+    percent_overlap=0.4,
+    data=projection,
+)
 
 # %%
 # Defining a clusterer
@@ -44,8 +47,7 @@ clusterer = zm.sk_learn(sk)
 
 result = zm.mapper(
     data=data,
-    projection=projection,
-    cover_scheme=cover_scheme,
+    cover=cover,
     clusterer=clusterer,
     dim=1,
 )

--- a/packages/zen-mapper/examples/custom_clusterer.py
+++ b/packages/zen-mapper/examples/custom_clusterer.py
@@ -145,14 +145,17 @@ plt.show()
 #
 # Now we have a clusterer compatible with zen-mapper.
 
-cover_scheme = zm.Width_Balanced_Cover(n_elements=5, percent_overlap=0.25)
-cover = cover_scheme(data)
+
 projection = data[:, 0]
+cover, _ = zm.width_balanced_cover(
+    n_elements=5,
+    percent_overlap=0.25,
+    data=projection,
+)
 
 result = zm.mapper(
     data=data,
-    projection=projection,
-    cover_scheme=cover_scheme,
+    cover=cover,
     clusterer=clusterer,
     dim=1,
 )

--- a/packages/zen-mapper/examples/custom_cover.py
+++ b/packages/zen-mapper/examples/custom_cover.py
@@ -9,109 +9,145 @@ actual implementation of the cover itself and there may be better ways.
 """
 
 # %%
-# Constructing a cover
+# Representing a cover
 # ====================
 #
-# We will start by defining an epsilon-net function. This will take a list of
-# centers, an epsilon, and a data array and return a list of numpy arrays.
+# Zen Mapper represents sets as numpy arrays of indices into a data array. That
+# is to say `np.array([1, 2, 5])` represents the set with elements `1`, `2`,
+# and `5` from the original, high dimensional data. Zen mapper then represents
+# a cover as an :term:`Iterable <python:iterable>` of these cover elements. If you're not
+# comfortable with what an :term:`Iterable <python:iterable>` is, you can think of them as a
+# :class:`list` for now. To construct a cover that zen mapper understands will
+# require us to adhere to this format.
+
+# %%
+# Constructing an epsilon net
+# ===========================
+#
+# An epsilon-net is a collection of balls of radius epsilon. The covers used in
+# ball mapper are all variations on generating an epsilon-net. So to start we
+# will focus on creating a function which takes a description of an epsilon-net
+# along with some data and constructs a cover as outlined in the previous
+# section.
 
 import numpy as np
-
-import zen_mapper as zm
 
 
 def epsilon_net(centers, epsilon, data) -> list[np.ndarray]:
     if len(data.shape) == 1:
         data.reshape(-1, 1)
 
-    result = []
+    cover = []
     for center in centers:
-        current = []
-        for i, datum in enumerate(data):
-            if np.sum((center - datum) ** 2) < epsilon**2:
-                current.append(i)
-        result.append(np.array(current, dtype=int))
+        # Create a new cover element for each center point
+        cover_element = []
 
-    return result
+        for i, datum in enumerate(data):
+            # Check if the distance between the center point
+            # and the data point is less than epsilon
+            if np.sum((center - datum) ** 2) < epsilon**2:
+                # If so append it to our cover element
+                cover_element.append(i)
+
+        # Finally add our cover element to the result
+        cover.append(np.array(cover_element, dtype=int))
+
+    return cover
 
 
 # %%
-# It is worth noting that :class:`list[np.ndarray]` implements the
-# :class:`Cover <zen_mapper.types.Cover>` protocol and so `epsilon_net` is
-# returning a valid `zen_mapper` cover. We can then visualize that this cover
-# acts as we hope it would
-
+# It is worth noting that :class:`list`\[:class:`numpy.ndarray`] is an :term:`Iterable
+# <python:iterable>` and so is understood by zen mapper. We can then visualize
+# that this cover acts as we hope it would.
 import matplotlib.pyplot as plt
 
+# We construct a diagonal dataset
 data = np.c_[np.arange(11), np.arange(11)]
 centers = np.array([[5, 5], [3, 3]])
 epsilon = 2
 
 ax = plt.gca()
+
+# Plot the dataset
 ax.scatter(data[:, 0], data[:, 1])
+
+# Compute the cover
 cover = epsilon_net(centers, epsilon, data)
 
-for element in cover:
-    ax.scatter(data[element, 0], data[element, 1])
+# Plot each element of that cover
+for i, element in enumerate(cover):
+    ax.scatter(
+        data[element, 0],
+        data[element, 1],
+        label=f"Cover Element {i}",
+    )
 
+# Visualize each epsilon ball
 for center in centers:
     circ = plt.Circle(center, epsilon, color="r", fill=False)
     ax.add_patch(circ)
 
 ax.set_aspect("equal")
+ax.legend()
 plt.show()
 
+
 # %%
-# Creating a covering scheme
-# ==========================
+# A greedy epsilon net
+# ====================
 #
-# The mapper function in zen_mapper expects a `covering_scheme` which is simply
-# a function which takes data and returns a cover. I find pythons partial
-# function support to be kind of awkward. So instead of defining a function we
-# will define a class with the `__call__` method which python will treat like
-# a function.
+# Ball mapper goes on to define a "greedy" epsilon net. The user specifies a
+# dataset and an epsilon value and from there the algorithm proceeds to
+# repeatedly choose a point not currently covered by the epsilon net and adds
+# this point as a center point to the net. We will define a function which
+# implements this algorithm.
 
 
-class Greedy_Epsilon_Net:
-    def __init__(self, epsilon: float):
-        self.epsilon = epsilon
-        self.centers = None
+def greedy_epsilon_net(epsilon: float, data: np.ndarray):
+    # These are the points which are not covered
+    to_cover = set(range(len(data)))
 
-    def __call__(self, data: np.ndarray) -> list[np.ndarray]:
-        to_cover = set(range(len(data)))
+    centers = []
 
-        centers = []
+    # If there are still points to cover
+    while to_cover:
+        # Pick the first one in the set
+        new_center = to_cover.pop()
 
-        while to_cover:
-            new_center = to_cover.pop()
-            centers.append(data[new_center])
-            covered = set()
+        # Add it to the list of centers
+        centers.append(data[new_center])
+        covered = set()
 
-            for point in to_cover:
-                if np.sum((data[new_center] - data[point]) ** 2) < self.epsilon**2:
-                    covered.add(point)
+        for point in to_cover:
+            # Mark the point as covered
+            if np.sum((data[new_center] - data[point]) ** 2) < epsilon**2:
+                covered.add(point)
 
-            to_cover -= covered
+        # Remove all the points we covered from the set to cover
+        to_cover -= covered
 
-        self.centers = centers
+    # Construct the cover from these center points
+    cover = epsilon_net(centers, epsilon, data)
 
-        return epsilon_net(centers, self.epsilon, data)
+    # Return the cover along with the centers
+    return cover, centers
 
 
 # %%
-# we can then visualize the covering scheme in much the same way we visualized the cover
+# By returning the center points along with the cover we allow users to
+# introspect how the cover was constructed. We can then visualize the covering
+# scheme in much the same way we visualized the cover.
 
 data = np.c_[np.arange(11), np.arange(11)]
-scheme = Greedy_Epsilon_Net(epsilon=2)
+cover, centers = greedy_epsilon_net(epsilon=2, data=data)
 
 ax = plt.gca()
 ax.scatter(data[:, 0], data[:, 1])
-cover = scheme(data)
 
 for element in cover:
     ax.scatter(data[element, 0], data[element, 1])
 
-for center in scheme.centers:
+for center in centers:
     circ = plt.Circle(center, epsilon, color="r", fill=False)
     ax.add_patch(circ)
 
@@ -142,9 +178,31 @@ plt.gca().set_aspect("equal")
 plt.show()
 
 # %%
-# We also need to define a clustering algorithm. In this paper they don't
+# We then can fit our cover to this data set, visualizing it as we did in
+# previous examples
+
+epsilon = 1.25
+cover, centers = greedy_epsilon_net(data=data, epsilon=epsilon)
+
+ax = plt.gca()
+ax.scatter(data[:, 0], data[:, 1])
+
+for element in cover:
+    ax.scatter(data[element, 0], data[element, 1])
+
+for center in centers:
+    circ = plt.Circle(center, epsilon, color="r", fill=False)
+    ax.add_patch(circ)
+
+ax.set_aspect("equal")
+plt.show()
+
+# %%
+# Finally we need to define a clustering algorithm. In this paper they don't
 # actually cluster anything, instead any datapoint in the ball is deemed to be
-# connected. So we define the following trivial clusterer.
+# connected. So we define the following trivial clusterer. See
+# :ref:`sphx_glr_examples_custom_clusterer.py` for more  information on how to
+# construct a clusterer for zen mapper.
 
 
 def trivial(data: np.ndarray, elements: np.ndarray):
@@ -157,10 +215,11 @@ def trivial(data: np.ndarray, elements: np.ndarray):
 
 import networkx as nx
 
+import zen_mapper as zm
+
 result = zm.mapper(
     data=data,
-    projection=data,
-    cover_scheme=Greedy_Epsilon_Net(1),
+    cover=cover,
     clusterer=trivial,
     dim=1,
 )

--- a/packages/zen-mapper/examples/distance_matrix.py
+++ b/packages/zen-mapper/examples/distance_matrix.py
@@ -70,12 +70,11 @@ clusterer = zm.sk_learn(sk)
 # %%
 # Computing the mapper graph
 # ==========================
-cover_scheme = zm.Width_Balanced_Cover(n_elements=3, percent_overlap=0.4)
+cover, _ = zm.width_balanced_cover(n_elements=3, percent_overlap=0.4, data=projection)
 
 result = zm.mapper(
     data=data,
-    projection=projection,
-    cover_scheme=cover_scheme,
+    cover=cover,
     clusterer=clusterer,
     dim=1,
 )

--- a/packages/zen-mapper/examples/enable_logging.py
+++ b/packages/zen-mapper/examples/enable_logging.py
@@ -23,8 +23,8 @@ logging.basicConfig(level=logging.INFO)
 # %%
 # Generating data
 # ===============
-import numpy as np
 import matplotlib.pyplot as plt
+import numpy as np
 
 theta = np.linspace(0, 2 * np.pi, 50)
 data = np.c_[np.cos(theta), np.sin(theta)]
@@ -35,15 +35,18 @@ plt.show()
 # Running mapper
 # ===============
 import networkx as nx
-from zen_mapper.adapters import to_networkx
 from sklearn.cluster import AgglomerativeClustering
-from zen_mapper.adapters import sk_learn
-from zen_mapper import mapper, Width_Balanced_Cover
+
+from zen_mapper import mapper, width_balanced_cover
+from zen_mapper.adapters import sk_learn, to_networkx
 
 projection = data[:, 0]
 
-cover_scheme = Width_Balanced_Cover(n_elements=3, percent_overlap=0.4)
-cover = cover_scheme(projection)
+cover, _ = width_balanced_cover(
+    n_elements=3,
+    percent_overlap=0.4,
+    data=projection,
+)
 
 sk = AgglomerativeClustering(
     linkage="single",
@@ -55,8 +58,7 @@ clusterer = sk_learn(sk)
 
 result = mapper(
     data=data,
-    projection=projection,
-    cover_scheme=cover_scheme,
+    cover=cover,
     clusterer=clusterer,
     dim=1,
 )

--- a/packages/zen-mapper/examples/extracting_data.py
+++ b/packages/zen-mapper/examples/extracting_data.py
@@ -36,15 +36,18 @@ from sklearn.cluster import DBSCAN
 
 import zen_mapper as zm
 
-cover_scheme = zm.Width_Balanced_Cover(n_elements=7, percent_overlap=0.2)
 projection = data[:, 0]
+cover, _ = zm.width_balanced_cover(
+    n_elements=7,
+    percent_overlap=0.2,
+    data=projection,
+)
 clusterer = zm.sk_learn(DBSCAN(eps=0.5))
 
 result = zm.mapper(
     data=data,
-    projection=projection,
     clusterer=clusterer,
-    cover_scheme=cover_scheme,
+    cover=cover,
     dim=1,
 )
 

--- a/packages/zen-mapper/src/zen_mapper/__init__.py
+++ b/packages/zen-mapper/src/zen_mapper/__init__.py
@@ -6,7 +6,6 @@ from .adapters import sk_learn, to_networkx
 from .cover import (
     Data_Balanced_Cover,
     Width_Balanced_Cover,
-    precomputed_cover,
     rectangular_cover,
 )
 from .mapper import mapper
@@ -17,7 +16,6 @@ __all__ = [
     "Data_Balanced_Cover",
     "Width_Balanced_Cover",
     "mapper",
-    "precomputed_cover",
     "rectangular_cover",
     "sk_learn",
     "to_networkx",

--- a/packages/zen-mapper/src/zen_mapper/__init__.py
+++ b/packages/zen-mapper/src/zen_mapper/__init__.py
@@ -4,7 +4,7 @@ import logging
 
 from .adapters import sk_learn, to_networkx
 from .cover import (
-    Data_Balanced_Cover,
+    data_balanced_cover,
     rectangular_cover,
     width_balanced_cover,
 )
@@ -13,7 +13,7 @@ from .types import MapperResult
 
 __all__ = [
     "MapperResult",
-    "Data_Balanced_Cover",
+    "data_balanced_cover",
     "width_balanced_cover",
     "mapper",
     "rectangular_cover",

--- a/packages/zen-mapper/src/zen_mapper/__init__.py
+++ b/packages/zen-mapper/src/zen_mapper/__init__.py
@@ -5,8 +5,8 @@ import logging
 from .adapters import sk_learn, to_networkx
 from .cover import (
     Data_Balanced_Cover,
-    Width_Balanced_Cover,
     rectangular_cover,
+    width_balanced_cover,
 )
 from .mapper import mapper
 from .types import MapperResult
@@ -14,7 +14,7 @@ from .types import MapperResult
 __all__ = [
     "MapperResult",
     "Data_Balanced_Cover",
-    "Width_Balanced_Cover",
+    "width_balanced_cover",
     "mapper",
     "rectangular_cover",
     "sk_learn",

--- a/packages/zen-mapper/src/zen_mapper/cover.py
+++ b/packages/zen-mapper/src/zen_mapper/cover.py
@@ -1,14 +1,15 @@
 from __future__ import annotations
 
 import logging
+from typing import TypedDict
 
 import numpy as np
 import numpy.typing as npt
 
 __all__ = [
     "rectangular_cover",
-    "Width_Balanced_Cover",
     "Data_Balanced_Cover",
+    "width_balanced_cover",
 ]
 
 logger = logging.getLogger("zen_mapper")
@@ -117,62 +118,96 @@ def _grid(
     return np.stack(grid, axis=-1).reshape(-1, len(start))
 
 
-class Width_Balanced_Cover:
-    """A cover comprised of equally sized rectangular elements
+class WidthBalancedMetadata(TypedDict):
+    """Geometric information about a width balanced cover
 
-    Parameters
-    ----------
-    n_elements : ArrayLike
-        The number of covering elements along each dimension. If the data is
-        dimension $d$ and this is a scalar $n$ this results in $n^d$ covering elements.
-    percent_overlap : float
-        a number between 0 and 1 representing the ammount of overlap between
-        adjacent covering elements.
-
-
-    Raises
-    ------
-    Value Error
-        if n_elements < 1
-    Value Error
-        if percent_overlap is not in (0,1)
+    After fitting a cover using :func:`width_balanced_cover` this contains all
+    the information you would need to reconstruct the cover using
+    :func:`rectangular_cover`, fit new data, or visualize the cover
+    geometrically.
     """
 
-    def __init__(self, n_elements: npt.ArrayLike, percent_overlap: float):
-        n_elements = np.array([n_elements], dtype=int)
+    centers: np.ndarray
+    """The coordinates of the centers for each rectangular covering element."""
+    widths: np.ndarray
+    """The calculated width of the covering elements across each dimension."""
 
-        if np.any(n_elements < 1):
-            raise ValueError("n_elements must be at least 1")
 
-        if not 0 < percent_overlap < 1:
-            raise ValueError("percent_overlap must be in the range (0,1)")
+def width_balanced_cover(
+    n_elements: npt.ArrayLike,
+    percent_overlap: float,
+    data: npt.ArrayLike,
+) -> tuple[list[np.ndarray], WidthBalancedMetadata]:
+    """Compute a cover of equally sized rectangular elements.
 
-        self.n_elements = n_elements
-        self.percent_overlap = percent_overlap
+    The widths of the intervals are calculated so that the entire range of the
+    data is spanned by the desired number of elements with the specified
+    overlap percentage.
 
-    def __call__(self, data):
-        logger.info("Computing the width balanced cover")
+    Args:
+        n_elements: The number of covering elements along each dimension. If
+            the data is dimension :math:`d` and this is a scalar :math:`n` this
+            results in :math:`n^d` covering elements.
+        percent_overlap: A number between 0 and 1 representing the amount of
+            overlap between adjacent covering elements.
+        data: The input data array to be covered. Of shape `(n_samples,
+            n_features)` or `(n_samples,)`.
 
-        if len(data.shape) == 1:
-            data = data.reshape(-1, 1)
+    Returns:
+        A tuple `(cover, metadata)` where `cover` is the fitted cover and `metadata`
+        is a dictionary containing geometric properties of the generated cover.
+        See :class:`WidthBalancedMetadata` for more information.
 
-        upper_bound = np.max(data, axis=0).astype(float)
-        lower_bound = np.min(data, axis=0).astype(float)
+    Raises:
+        ValueError: If any value in `n_elements` is  less than 1.
+        ValueError: If `percent_overlap` is not in the open interval (0,1)
+    """
 
-        width = (upper_bound - lower_bound) / (
-            self.n_elements - (self.n_elements - 1) * self.percent_overlap
+    n_elements = np.atleast_1d(n_elements)
+
+    data = np.asarray(data, dtype=float)
+
+    if data.ndim < 2:
+        logger.warning(
+            "Data has shape %s, reshaping to (%s, 1)",
+            data.shape,
+            data.size,
         )
-        width = width.flatten()
-        self.width = width
+        data = data.reshape(-1, 1)
 
-        # Compute the centers of the "lower left" and "upper right" cover
-        # elements
-        upper_bound -= width / 2
-        lower_bound += width / 2
+    if data.ndim > 2:
+        raise ValueError(
+            f"Shape of data must be (n_samples, n_features), got f{data.shape}"
+        )
 
-        centers = _grid(lower_bound, upper_bound, self.n_elements)
-        self.centers = centers
-        return rectangular_cover(centers, width, data)
+    if np.any(n_elements < 1):
+        raise ValueError(f"n_elements must be at least 1, got {n_elements}")
+
+    if not 0 < percent_overlap < 1:
+        raise ValueError(
+            f"percent_overlap must be in the range (0,1), got {percent_overlap}"
+        )
+
+    logger.info("Computing the width balanced cover")
+
+    upper_bound = np.max(data, axis=0)
+    lower_bound = np.min(data, axis=0)
+
+    width = (upper_bound - lower_bound) / (
+        n_elements - (n_elements - 1) * percent_overlap
+    )
+    width = width.flatten()
+
+    # Compute the centers of the "lower left" and "upper right" cover
+    # elements
+    upper_bound -= width / 2
+    lower_bound += width / 2
+
+    centers = _grid(lower_bound, upper_bound, n_elements)
+    return rectangular_cover(centers, width, data), {
+        "centers": centers,
+        "widths": width,
+    }
 
 
 class Data_Balanced_Cover:

--- a/packages/zen-mapper/src/zen_mapper/cover.py
+++ b/packages/zen-mapper/src/zen_mapper/cover.py
@@ -5,31 +5,13 @@ import logging
 import numpy as np
 import numpy.typing as npt
 
-from .types import Cover
-
 __all__ = [
-    "precomputed_cover",
     "rectangular_cover",
     "Width_Balanced_Cover",
     "Data_Balanced_Cover",
 ]
 
 logger = logging.getLogger("zen_mapper")
-
-
-def precomputed_cover(cover: Cover) -> CoverScheme:
-    """A precomputed cover
-
-    Parameters
-    ----------
-    cover : Cover
-        the precomputed cover to use
-    """
-
-    def inner(*_):
-        return cover
-
-    return inner  # type: ignore
 
 
 def rectangular_cover(

--- a/packages/zen-mapper/src/zen_mapper/cover.py
+++ b/packages/zen-mapper/src/zen_mapper/cover.py
@@ -8,8 +8,8 @@ import numpy.typing as npt
 
 __all__ = [
     "rectangular_cover",
-    "Data_Balanced_Cover",
     "width_balanced_cover",
+    "data_balanced_cover",
 ]
 
 logger = logging.getLogger("zen_mapper")
@@ -210,9 +210,12 @@ def width_balanced_cover(
     }
 
 
-class Data_Balanced_Cover:
-    r"""
-    A cover of 1D data with roughly equal data points per interval.
+def data_balanced_cover(
+    n_elements: int,
+    percent_overlap: float,
+    data: npt.ArrayLike,
+) -> tuple[list[np.ndarray], DataBalancedMetadata]:
+    r"""Compute a cover with roughly equal data points per interval
 
     The cover is constructed by partitioning the sorted indices :math:`[0, \dots, N-1]`
     into intervals of approximately equal size, then mapping those
@@ -228,88 +231,76 @@ class Data_Balanced_Cover:
 
     where :math:`k` is `n_elements`.
 
-    Parameters
-    ----------
-    n_elements : int
-        The number of intervals (cover elements) to create. Must be :math:`\ge 1`.
-    percent_overlap : float
-        The fractional overlap between adjacent intervals, :math:`0 <
-        \text{overlap} < 1`.
+    Args:
+        n_elements: The number of intervals (cover elements) to create. Must be
+            at least 1.
+        percent_overlap: The fractional overlap between adjacent intervals.
+            Must be between 0 and 1 exclusive.
 
-    Attributes
-    ----------
-    n_elements : int
-        The number of cover elements.
-    percent_overlap : float
-        The fractional overlap.
+    Returns:
+        A tuple `(cover, metadata)` where `cover` is the fitted cover and
+        `metadata` is a dictionary containing geometric properties of the
+        generated cover. See :class:`DataBalancedMetadata` for more
+        information.
 
-    Raises
-    ------
-    ValueError
-        If `n_elements` < 1 or `percent_overlap` is not in the range (0, 1).
+    Raises:
+        ValueError: If `n_elements` < 1 or `percent_overlap` is not in the
+            open range (0, 1).
 
-    Notes
-    -----
-    A `percent_overlap` of 0.5 means each interval shares approximately 50%
-    of its points with the subsequent interval.
+    Note:
+        A `percent_overlap` of 0.5 means each interval shares approximately 50%
+        of its points with the subsequent interval.
+
+    Examples:
+        >>> data = np.array([10, 11, 12, 40, 55, 60])
+        >>> cover, meta = data_balanced_cover(2, 0.5, data)
+        >>> cover
+        [array([0, 1, 2, 3]), array([2, 3, 4, 5])]
+        >>> [ data[e] for e in cover ]
+        [array([10, 11, 12, 40]), array([12, 40, 55, 60])]
+        >>> bounds = meta["bounds"]
+        >>> bounds
+        array([[0, 3],
+               [2, 5]])
+        >>> data[bounds]
+        array([[10, 40],
+               [12, 60]])
     """
 
-    def __init__(self, n_elements: int, percent_overlap: float):
-        self._cover = Width_Balanced_Cover(
-            n_elements=n_elements,
-            percent_overlap=percent_overlap,
+    data = np.atleast_1d(data)
+
+    if data.ndim != 1:
+        raise ValueError(
+            f"Data_Balanced_Cover only supports 1-dimensional input"
+            f"data but received data with shape: {data.shape}"
         )
-        self.n_elements = n_elements
-        self.percent_overlap = percent_overlap
 
-    def __call__(self, data: npt.ArrayLike):
-        """
-        Partition the input data into overlapping intervals containing
-        approximately equal numbers of points.
+    n = len(data)
 
-        This method sorts the input data and applies a width-balanced cover
-        to the indices. It then maps these index-based regions back to the
-        original data indices to create the balanced cover.
+    if n < n_elements:
+        raise ValueError("Number of data points must be >= n_elements")
 
-        Parameters
-        ----------
-        data : array_like
-            A 1-dimensional array of data points to be partitioned.
+    logger.info("Computing the data balanced cover")
 
-        Returns
-        -------
-        list of ndarray
-            A list containing the indices of the original data points
-            belonging to each cover element. Each element in the list is
-            an `np.ndarray`.
+    sort_idx = np.argsort(data)
+    idxs = np.arange(n)
+    cover_idxs, _ = width_balanced_cover(
+        n_elements=n_elements,
+        percent_overlap=percent_overlap,
+        data=idxs,
+    )
 
-        Raises
-        ------
-        ValueError
-            If the input `data` is not 1-dimensional.
-        ValueError
-            If the number of points in `data` is less than the requested
-            `n_elements`.
-        """
-        data = np.asarray(data, dtype=float)
+    cover = [sort_idx[g] for g in cover_idxs]
 
-        if data.ndim != 1:
-            raise ValueError(
-                f"Data_Balanced_Cover only supports 1-dimensional input"
-                f"(projected) data but received data with dim: {data.ndim}"
-            )
+    bounds = np.fromiter(
+        ((e[0], e[-1]) for e in cover),
+        dtype=np.dtype((int, 2)),
+        count=len(cover),
+    )
 
-        logger.info("Computing the data balanced cover")
+    return cover, {"bounds": bounds}
 
-        n = len(data)
 
-        if n < self.n_elements:
-            raise ValueError("Number of data points must be >= n_elements")
-
-        sort_idx = np.argsort(data)
-        idxs = np.arange(n)
-        cover_idxs = self._cover(idxs)
-
-        cover = [sort_idx[g] for g in cover_idxs]
-
-        return cover
+class DataBalancedMetadata(TypedDict):
+    bounds: np.ndarray
+    """The indices of the bounds for each interval. Shape `(num_intervals, 2)`"""

--- a/packages/zen-mapper/src/zen_mapper/cover.py
+++ b/packages/zen-mapper/src/zen_mapper/cover.py
@@ -5,7 +5,7 @@ import logging
 import numpy as np
 import numpy.typing as npt
 
-from .types import Cover, CoverScheme
+from .types import Cover
 
 __all__ = [
     "precomputed_cover",

--- a/packages/zen-mapper/src/zen_mapper/cover.py
+++ b/packages/zen-mapper/src/zen_mapper/cover.py
@@ -161,6 +161,19 @@ def width_balanced_cover(
     Raises:
         ValueError: If any value in `n_elements` is  less than 1.
         ValueError: If `percent_overlap` is not in the open interval (0,1)
+
+    Examples:
+        >>> data = np.array([10, 11, 12, 40, 55, 60])
+        >>> cover, meta = width_balanced_cover(2, 0.5, data)
+        >>> cover
+        [array([0, 1, 2, 3]), array([3, 4, 5])]
+        >>> [ data[e] for e in cover ]
+        [array([10, 11, 12, 40]), array([40, 55, 60])]
+        >>> meta["centers"] # The center of each interval
+        array([[26.66666667],
+               [43.33333333]])
+        >>> meta["widths"] # The width of each interval
+        array([33.33333333])
     """
 
     n_elements = np.atleast_1d(n_elements)

--- a/packages/zen-mapper/src/zen_mapper/mapper.py
+++ b/packages/zen-mapper/src/zen_mapper/mapper.py
@@ -7,7 +7,7 @@ from typing import TypeVar
 
 import numpy as np
 
-from .types import Clusterer, CoverScheme, Komplex, MapperResult, Simplex
+from .types import Clusterer, Cover, Komplex, MapperResult, Simplex
 
 __all__ = ["mapper"]
 
@@ -19,8 +19,7 @@ H = TypeVar("H")  # High dimensional data
 
 def mapper(
     data: H,
-    projection: np.ndarray,
-    cover_scheme: CoverScheme,
+    cover: Cover,
     clusterer: Clusterer[H, M],
     dim: int | None,
     min_intersection: int = 1,
@@ -30,10 +29,7 @@ def mapper(
 
     Args:
         data: The high dimensional dataset
-        projection: The output of the lens/filter function on the data. Must have
-            the same number of elements as data.
-        cover_scheme: For cover generation. Should be a callable object that takes
-            a numpy array and returns a list of list(indices).
+        cover: A cover of `data`
         clusterer: A callable object that takes in a dataset and returns an
             iterator of numpy arrays which contain indices for clustered points.
         dim: The highest dimension of the mapper complex to compute.
@@ -50,7 +46,7 @@ def mapper(
     cover_id = list()
     metadata = list()
 
-    cover_elements = map(np.asarray, cover_scheme(projection))
+    cover_elements = map(np.asarray, cover)
 
     for i, element in enumerate(cover_elements):
         if len(element) == 0:

--- a/packages/zen-mapper/src/zen_mapper/test_cluster.py
+++ b/packages/zen-mapper/src/zen_mapper/test_cluster.py
@@ -2,7 +2,6 @@ import numpy as np
 from sklearn.cluster import DBSCAN
 
 from zen_mapper import mapper
-from zen_mapper.cover import precomputed_cover
 
 from .adapters import sk_learn
 
@@ -38,8 +37,7 @@ def test_non_array_cluster():
     data = np.empty(N_SAMPLES)
     mapper(
         data=data,
-        projection=data,
-        cover_scheme=precomputed_cover([np.arange(N_SAMPLES)]),
+        cover=[np.arange(N_SAMPLES)],
         clusterer=_trivial_cluster,
         dim=0,
     )

--- a/packages/zen-mapper/src/zen_mapper/test_cover.py
+++ b/packages/zen-mapper/src/zen_mapper/test_cover.py
@@ -8,9 +8,9 @@ from hypothesis.strategies import fixed_dictionaries, floats, integers, just
 
 from zen_mapper.cover import (
     Data_Balanced_Cover,
-    Width_Balanced_Cover,
     _grid,
     rectangular_cover,
+    width_balanced_cover,
 )
 
 
@@ -111,8 +111,8 @@ def test_grid_array_steps(args):
 )
 def test_width_balanced(data, n, gain):
     """Ensure that a width balanced cover covers the entire dataset"""
-    cover_scheme = Width_Balanced_Cover(n, gain)
-    covered_data = reduce(lambda acc, new: acc.union(new), cover_scheme(data), set())
+    cover, _ = width_balanced_cover(n, gain, data)
+    covered_data = reduce(lambda acc, new: acc.union(new), cover, set())
     assert len(data) == len(covered_data)
 
 
@@ -121,16 +121,16 @@ def test_width_balanced_multiple_widths():
     data = np.arange(100).reshape((25, 4))
     gain = 0.4
     n = [1, 1, 2, 2]
-    cover_scheme = Width_Balanced_Cover(n, gain)
-    covered_data = reduce(lambda acc, new: acc.union(new), cover_scheme(data), set())
+    cover, _ = width_balanced_cover(n, gain, data)
+    covered_data = reduce(lambda acc, new: acc.union(new), cover, set())
     assert len(data) == len(covered_data)
 
 
 def test_width_balanced_int():
     """Ensure that width balanced covers handle integer data gracefully"""
     data = np.arange(100, dtype=int)
-    cover_scheme = Width_Balanced_Cover(3, 0.4)
-    covered_data = reduce(lambda acc, new: acc.union(new), cover_scheme(data), set())
+    cover, _ = width_balanced_cover(3, 0.4, data)
+    covered_data = reduce(lambda acc, new: acc.union(new), cover, set())
     assert len(data) == len(covered_data)
 
 

--- a/packages/zen-mapper/src/zen_mapper/test_cover.py
+++ b/packages/zen-mapper/src/zen_mapper/test_cover.py
@@ -7,8 +7,8 @@ from hypothesis.extra import numpy
 from hypothesis.strategies import fixed_dictionaries, floats, integers, just
 
 from zen_mapper.cover import (
-    Data_Balanced_Cover,
     _grid,
+    data_balanced_cover,
     rectangular_cover,
     width_balanced_cover,
 )
@@ -138,14 +138,14 @@ def test_data_balanced_simple():
     """
     Test that Data_Balanced_Cover partitions data as expected for a tiny array.
     """
-    cover = Data_Balanced_Cover(2, 0.5)
     data = np.array([10, 20, 30, 40, 50, 60])
+    cover, _ = data_balanced_cover(2, 0.5, data)
     expected = {
         frozenset({0, 1, 2, 3}),
         frozenset({2, 3, 4, 5}),
     }
 
-    groups = set(map(frozenset, cover(data)))
+    groups = set(map(frozenset, cover))
     assert expected == groups
 
 
@@ -156,8 +156,7 @@ def test_data_balanced_complete_coverage_random():
     n_elements = 5
     overlap = 0.3
 
-    cover = Data_Balanced_Cover(n_elements, overlap)
-    groups = cover(data)
+    groups, _ = data_balanced_cover(n_elements, overlap, data)
 
     all_indices = set(np.concatenate(groups))
     assert all_indices == set(range(len(data)))
@@ -167,27 +166,27 @@ def test_data_balanced_small_dataset_error():
     """Should raise ValueError if data has fewer points than groups."""
     data = np.arange(3)
     with pytest.raises(ValueError):
-        Data_Balanced_Cover(5, 0.4)(data)
+        data_balanced_cover(5, 0.4, data)
 
 
 @pytest.mark.parametrize("overlap", [0, 1, -0.1, 2.0])
 def test_data_balanced_invalid_overlap(overlap):
     """Should reject invalid percent_overlap."""
     with pytest.raises(ValueError):
-        Data_Balanced_Cover(3, overlap)
+        data_balanced_cover(3, overlap, [])
 
 
 def test_data_balanced_invalid_n_elements():
     """Should reject n_elements < 1."""
     with pytest.raises(ValueError):
-        Data_Balanced_Cover(0, 0.4)
+        data_balanced_cover(0, 0.4, [])
 
 
 def test_data_balanced_only_1d_allowed():
     """Multi-dimensional data should be rejected."""
     data = np.random.rand(10, 2)
     with pytest.raises(ValueError):
-        Data_Balanced_Cover(3, 0.4)(data)
+        data_balanced_cover(3, 0.4, data)
 
 
 def test_data_balanced_cover_structure():
@@ -195,8 +194,7 @@ def test_data_balanced_cover_structure():
     data = np.linspace(0, 100, 101)
     n_elements = 4
     overlap = 0.25
-    cover = Data_Balanced_Cover(n_elements, overlap)
-    groups = cover(data)
+    groups, _ = data_balanced_cover(n_elements, overlap, data)
 
     # No repeat elements in any cover element
     for g in groups:
@@ -213,3 +211,16 @@ def test_data_balanced_cover_structure():
 
     # Every index is present
     assert set(all_idx) == set(range(len(data)))
+
+
+def test_data_balanced_bounds():
+    """
+    Check that the bounds reported by data_balanced_cover agree with the
+    computed cover.
+    """
+    data = np.array([10, 20, 30, 40, 50, 60])
+    cover, meta = data_balanced_cover(2, 0.5, data)
+
+    for element, (bound_l, bound_u) in zip(cover, data[meta["bounds"]]):
+        ind = (data <= bound_u) & (data >= bound_l)
+        assert sorted(data[ind]) == sorted(data[element])

--- a/packages/zen-mapper/src/zen_mapper/test_mapper.py
+++ b/packages/zen-mapper/src/zen_mapper/test_mapper.py
@@ -2,7 +2,7 @@ import numpy as np
 from sklearn.cluster import DBSCAN
 
 from .adapters import sk_learn
-from .cover import Width_Balanced_Cover
+from .cover import width_balanced_cover
 from .mapper import mapper
 
 
@@ -16,11 +16,11 @@ def test_mapper():
     data = np.column_stack([np.cos(theta), np.sin(theta)])
     db = DBSCAN(eps=0.1, min_samples=2)
     clusterer = sk_learn(db)
-    cover_scheme = Width_Balanced_Cover(3, 0.4)
+    projection = data[:, 0]
+    cover, _ = width_balanced_cover(3, 0.4, projection)
     result = mapper(
         data=data,
-        projection=data[:, 0],
-        cover_scheme=cover_scheme,
+        cover=cover,
         clusterer=clusterer,
         dim=1,
     )

--- a/packages/zen-mapper/src/zen_mapper/test_mapper.py
+++ b/packages/zen-mapper/src/zen_mapper/test_mapper.py
@@ -2,7 +2,7 @@ import numpy as np
 from sklearn.cluster import DBSCAN
 
 from .adapters import sk_learn
-from .cover import Width_Balanced_Cover, precomputed_cover
+from .cover import Width_Balanced_Cover
 from .mapper import mapper
 
 
@@ -29,35 +29,3 @@ def test_mapper():
     assert len(list(result.nerve)) == 8
     assert len(list(result.nerve[0])) == 4
     assert len(list(result.nerve[1])) == 4
-
-
-def test_precomputed_cover():
-    theta = np.linspace(
-        -np.pi,
-        np.pi,
-        1000,
-        endpoint=False,
-    )
-    data = np.column_stack([np.cos(theta), np.sin(theta)])
-    db = DBSCAN(eps=0.1, min_samples=2)
-    clusterer = sk_learn(db)
-    cover_scheme = Width_Balanced_Cover(3, 0.4)
-    result = mapper(
-        data=data,
-        projection=data[:, 0],
-        cover_scheme=cover_scheme,
-        clusterer=clusterer,
-        dim=1,
-    )
-
-    result2 = mapper(
-        data=data,
-        projection=data[:, 0],
-        cover_scheme=precomputed_cover(cover_scheme(data[:, 0])),
-        clusterer=clusterer,
-        dim=1,
-    )
-
-    assert len(list(result.nerve)) == len(list(result2.nerve))
-    assert len(list(result.nerve[0])) == len(list(result2.nerve[0]))
-    assert len(list(result.nerve[1])) == len(list(result2.nerve[1]))

--- a/packages/zen-mapper/src/zen_mapper/types.py
+++ b/packages/zen-mapper/src/zen_mapper/types.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
-from collections.abc import Collection, Iterable, Iterator
+from collections.abc import Collection, Iterable
 from dataclasses import dataclass
 from itertools import combinations
-from typing import Generic, Protocol, Self, TypeVar
+from typing import Generic, Protocol, Self, TypeAlias, TypeVar
 
 import numpy as np
 import numpy.typing as npt
@@ -11,7 +11,6 @@ import numpy.typing as npt
 __all__ = [
     "Clusterer",
     "Cover",
-    "CoverScheme",
     "Komplex",
     "MapperResult",
     "Simplex",
@@ -23,67 +22,26 @@ M = TypeVar("M", covariant=True)
 # High dimensional data type
 H = TypeVar("H", contravariant=True)
 
+Cover: TypeAlias = Iterable[np.ndarray]
+"""Zen mapper expects covers to be encoded as an iterable of sets
 
-class Cover(Protocol):
-    """
-    Protocol for a cover
-
-    A set is represented as a numpy array of indices into the original data
-    set. For instance `[0, 4, 3]` represents the set with the 0th, 4th, and 3rd
-    elements from the original dataset. A cover is a collection of these sets.
-    It is expected that these cover the dataset however no effort is made to
-    enforce this constraint.
-
-    Specifically we require that you can iterate over the sets in the cover and
-    that you can report the number of cover elements. In particular this means
-    a list of arrays or a set of arrays will work. It is unlikely that you will
-    actually implement this protocol, what you probably want is
-    :class:`CoverScheme`.
-    """
-
-    def __len__(self: Self) -> int:
-        """
-        The number of sets in the cover.
-
-        Returns:
-            The number of sets in the cover.
-        """
-        ...
-
-    def __iter__(self: Self) -> Iterator[npt.ArrayLike]:
-        """
-        Returns an iterator over the sets in the cover.
-
-        Each element yielded by the iterator is expected to be array-like,
-        suitable for conversion to a NumPy array. The elements of these arrays
-        are indices into the original data set
-
-        Yields:
-            A set in the cover
-        """
-        ...
+Here each set is encoded as numpy array of indices into the original dataset.
+For instance `[0, 3, 4]` would be the set that represents the zeroth, third,
+and fourth elements in a dataset. Zen mapper does not enforce that invalid sets
+are not passed in. It is up to the caller to make sure that there are no
+duplicated entries and that every index is valid.
 
 
-class CoverScheme(Protocol):
-    """
-    Protocol for a cover scheme
+See Also:
+    :doc:`/examples/custom_cover`: A narrated example of implementing
+    a new cover
 
-    A cover scheme is a function or callable object which takes the projected
-    data and produces a `Cover` object. See the example
-    :doc:`/examples/custom_cover` for a more detailed look at how to create a
-    custom covering scheme.
-    """
+    :mod:`zen_mapper.cover`: Basic methods for fitting covers
 
-    def __call__(self: Self, data: np.ndarray) -> Cover:
-        """Generate a `Cover` from the input data.
-
-        Args:
-            data: The input data
-
-        Returns:
-            The generated cover.
-        """
-        ...
+    :doc:`ADR-0005 </decisions/0005-use-numpy-array-to-encode-cover-elements>`
+    and :doc:`ADR-0006 </decisions/0006-encode-covers-as-iterable>` for
+    rational behind this encoding.
+"""
 
 
 class Simplex(tuple[int, ...]):


### PR DESCRIPTION
After a conversation with @AnderMiller we have decided that the "covering scheme" is probably an abstraction which is not carrying its weight. This is an exploration of just requiring the user to pass in a cover.

Some questions remain:

1. We have some built in covering schemes. How should they return their metadata? For now I have chosen to return `cover, metadata` which results in a potentially awkward pattern.

Todo:

- [x] update kaiju
- [x] update docs
- [x] probably something else iunno