### PR TITLE
zen mapper: update doc style

### DIFF
--- a/packages/zen-mapper/docs/source/api/.gitignore
+++ b/packages/zen-mapper/docs/source/api/.gitignore
@@ -1,0 +1,1 @@
+zen_mapper*

--- a/packages/zen-mapper/docs/source/api/index.rst
+++ b/packages/zen-mapper/docs/source/api/index.rst
@@ -1,0 +1,7 @@
+Api Docs
+========
+
+.. toctree::
+   :maxdepth: 4
+
+   zen_mapper

--- a/packages/zen-mapper/docs/source/conf.py
+++ b/packages/zen-mapper/docs/source/conf.py
@@ -46,6 +46,7 @@ autodoc_typehints_format = "short"
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
     "numpy": ("https://numpy.org/doc/stable/", None),
+    "networkx": ("https://networkx.org/documentation/stable/", None),
 }
 
 add_module_names = False

--- a/packages/zen-mapper/docs/source/conf.py
+++ b/packages/zen-mapper/docs/source/conf.py
@@ -19,23 +19,42 @@ release = "0.3.0"
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 
 extensions = [
+    "sphinx.ext.autodoc",
     "sphinx.ext.napoleon",
     "sphinx.ext.intersphinx",
     "myst_parser",
-    "autoapi.extension",
     "sphinx_gallery.gen_gallery",
     "sphinxcontrib.katex",
+    "sphinx_autodoc_typehints",
 ]
 
 templates_path = ["_templates"]
 exclude_patterns = []
 
 # -- Other documentation -----------------------------------------------------
-# https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html#confval-intersphinx_mapping
+
+# -- Options for api docs ----------------------------------------------------
+
+autodoc_default_options = {
+    "members": True,
+    "ignore-module-all": False,
+}
+
+autodoc_typehints = "description"
+autodoc_typehints_format = "short"
+
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
     "numpy": ("https://numpy.org/doc/stable/", None),
 }
+
+add_module_names = False
+
+typehints_defaults = "comma"
+typehints_document_rtype = True
+typehints_use_rtype = False
+napoleon_use_rtype = False
+add_function_parentheses = False
 
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
@@ -55,10 +74,6 @@ html_sidebars = {
         "navigation.html",
     ]
 }
-
-# -- Options for Api documentation --------------------------------------------
-autoapi_dirs = ["../../src/zen_mapper"]
-autoapi_ignore = ["**/test*.py"]
 
 # -- Options for example gallery ----------------------------------------------
 sphinx_gallery_conf = {

--- a/packages/zen-mapper/docs/source/decisions/0007-use-sphinx-apidoc.md
+++ b/packages/zen-mapper/docs/source/decisions/0007-use-sphinx-apidoc.md
@@ -1,0 +1,42 @@
+---
+status: "accepted"
+date: "2026-06-20"
+---
+# Use sphinx-apidoc
+
+## Context and Problem Statement
+
+We would like to automatically generate api docs using the doc strings of our
+methods. What tool should we use to generate those?
+
+## Decision Drivers
+
+- Ease of use, the more automatic the tool is the better
+- Well supported, we don't want the tool we use to suddenly go away
+- Supports type annotations, we would like to minimize the duplication of type
+  information if at all possible
+
+## Considered Options
+
+- [sphinx-apidoc](https://www.sphinx-doc.org/en/master/man/sphinx-apidoc.html)
+- [sphinx autoapi](https://sphinx-autoapi.readthedocs.io)
+
+## Decision Outcome
+
+"sphinx-apidoc", because it is distributed with sphinx and supports type
+annotations.
+
+## Pros and Cons of the Options
+
+### sphinx-apidoc
+
+- Good, because it is distributed with sphinx
+- Good, because it supports type annotations
+- Bad, because it requires running a separate tool to generate the api docs
+- Bad, because migration will take work
+
+### sphinx autoapi
+
+- Good, because we are already using it
+- Bad, because we now rely on a third party
+- Bad, because its type annotation support is "experimental" and may be removed

--- a/packages/zen-mapper/docs/source/decisions/0008-use-google-style-docstrings.md
+++ b/packages/zen-mapper/docs/source/decisions/0008-use-google-style-docstrings.md
@@ -1,0 +1,52 @@
+---
+status: "accepted"
+date: "2026-06-20"
+---
+# Use google style docstrings
+
+## Context and Problem Statement
+
+We would like to automatically generate api docs using the docstrings of our
+methods. How should we format these docstrings?
+
+## Decision Drivers
+
+- Ease of writing, it should be easy for an author to write these doc strings
+- Ease of reading, it should be easy to read these docstrings without rendering them
+- Supported by sphinx
+- Supports untyped parameters and returns, we have type hints for these
+
+## Considered Options
+
+- Google style docstrings
+- Numpy style docstrings
+- Sphinx style docstrings
+
+
+## Decision Outcome
+
+"Google style docstrings", because it supports untyped returns, is common, is
+easy to read, and easy to write.
+
+## Pros and Cons of the Options
+
+### Google style docstrings
+
+- Good, because common
+- Good, because supported in sphinx via napoleon
+- Good, because it supports untyped return values
+- Bad, because we will have to convert our current docstrings over
+
+### Numpy style docstrings
+
+- Good, because common
+- Good, because supported in sphinx via napoleon
+- Good, because we already use it
+- Bad, because does not support untyped return values
+
+### Sphinx style docstrings
+
+- Good, because supported in sphinx natively
+- Good, because it supports untyped return values
+- Bad, because we will have to convert our current docstrings over
+- Bad, because I am not that familiar with them

--- a/packages/zen-mapper/docs/source/index.md
+++ b/packages/zen-mapper/docs/source/index.md
@@ -50,8 +50,8 @@ correctly. There is plenty of room left for some pretty trivial optimizations.
 :hidden:
 :maxdepth: 4
 examples/index
-autoapi/index
 contributing
 changelog
 decisions/index
+api/index
 ```

--- a/packages/zen-mapper/justfile
+++ b/packages/zen-mapper/justfile
@@ -24,8 +24,12 @@ test:
 check check:
 	nix build .#checks.x86_64-linux.{{check}}
 
+# Generate Api Docs
+doc-generate:
+	sphinx-apidoc --separate --force --no-toc --output-dir docs/source/api src "src/**/test*"
+
 # Build the docs
-doc-build:
+doc-build: doc-generate
 	cd docs && make dirhtml
 
 # Serve the docs

--- a/packages/zen-mapper/pyproject.toml
+++ b/packages/zen-mapper/pyproject.toml
@@ -42,7 +42,7 @@ dev = [
 ]
 docs = [
     "myst-parser>=4.0.0",
-    "sphinx-autoapi>=3.3.3",
+    "sphinx-autodoc-typehints>=3.11.0",
     "sphinx-gallery>=0.18.0",
     "sphinx>=8.1.3",
     "sphinxcontrib-katex>=0.9.10",

--- a/packages/zen-mapper/src/zen_mapper/adapters.py
+++ b/packages/zen-mapper/src/zen_mapper/adapters.py
@@ -1,8 +1,10 @@
 """Adapters for converting between zen-mapper types and 3rd party types"""
 
+from __future__ import annotations
+
 import logging
 from collections.abc import Collection
-from typing import TypeVar
+from typing import TYPE_CHECKING, TypeVar
 
 import numpy as np
 import numpy.typing as npt
@@ -13,32 +15,29 @@ __all__ = ["to_networkx", "sk_learn"]
 
 logger = logging.getLogger("zen_mapper")
 
+if TYPE_CHECKING:
+    import networkx as nx
 
-def to_networkx(komplex: Komplex):
-    """Converts a zen-mapper komplex to a networkx graph
+
+def to_networkx(komplex: Komplex) -> nx.Graph:
+    """Convert a zen-mapper komplex to a networkx graph
 
     This function takes a `Komplex` object, which represents a simplicial complex,
     and converts it into a `networkx.Graph` object. The vertices of the `Komplex`
     become the nodes in the `networkx` graph, and the 1-simplices (edges) of
     the `Komplex` become the edges in the `networkx` graph.
 
-    Parameters
-    ----------
-    komplex : Komplex
-        The `Komplex` object to convert. This object is expected to
-        have a `vertices` attribute and support indexing for its
-        simplices (e.g., `komplex[1]` for 1-simplices).
+    Args:
+        komplex: The `Komplex` object to convert. This object is expected to
+            have a `vertices` attribute and support indexing for its simplices
+            (e.g., `komplex[1]` for 1-simplices).
 
-    Returns
-    -------
-    networkx.Graph
-        A `networkx.Graph` object representing the 0- and 1-dimensional
-        structure of the input `Komplex`.
+    Returns:
+        A graph representing the 0 and 1-dimensional structure of the input
+        `Komplex`.
 
-    Raises
-    ------
-    ImportError
-        If the `networkx` library is not installed.
+    Raises:
+        ImportError: If the `networkx` library is not installed.
     """
     try:
         import networkx as nx

--- a/packages/zen-mapper/src/zen_mapper/adapters.py
+++ b/packages/zen-mapper/src/zen_mapper/adapters.py
@@ -60,28 +60,23 @@ def sk_learn(
     base_clusterer: C,
     precomputed: bool | None = None,
 ) -> Clusterer[np.ndarray, C]:
-    """Wraps a scikit-learn clusterer for use with zen-mapper.
+    """Wrap a scikit-learn clusterer for use with zen-mapper.
 
     This function acts as an adapter, allowing scikit-learn's clustering
     algorithms to be integrated into the zen-mapper pipeline. Note: any
     datapoints which are considered noise by the base clusterer are ignored.
 
-    Parameters
-    ----------
-    base_clusterer : C
-        An instance of a scikit-learn compatible clustering algorithm.
-        This object should have a `fit_predict` method and a `labels_`
-        attribute after fitting, which is standard for scikit-learn
-        clusterers.
+    Args:
+        base_clusterer: An instance of a scikit-learn compatible clustering
+            algorithm. This object should have a `fit_predict` method and a
+            `labels_` attribute after fitting, which is standard for scikit-learn
+            clusterers.
 
-    precomputed : bool, optional
-        True if the scikit-learn algorithm is expecting a distance matrix. If
-        not specified the adapter attempts to detect this from
-        `base_clusterer`.
+        precomputed: True if the scikit-learn algorithm is expecting a distance
+            matrix. If not specified the adapter attempts to detect this from
+            `base_clusterer`.
 
-    Returns
-    -------
-    Clusterer[C]
+    Returns:
         An object conforming to the zen-mapper `Clusterer` protocol, which
         wraps the provided `clusterer`. This allows zen-mapper to use the
         scikit-learn clusterer's `fit_predict` methods within its pipeline. A

--- a/packages/zen-mapper/src/zen_mapper/mapper.py
+++ b/packages/zen-mapper/src/zen_mapper/mapper.py
@@ -24,32 +24,24 @@ def mapper(
     min_intersection: int = 1,
 ) -> MapperResult[M]:
     """
-    Constructs a simplicial complex representation of the data.
+    Construct a simplicial complex representation of the data.
 
-    Parameters
-    ----------
-    data: np.ndarray
-    projection: np.ndarray
-        The output of the lens/filter function on the data. Must have the same
-        number of elements as data.
-    cover_scheme: CoverScheme
-        For cover generation. Should be a callable object that takes a
-        numpy array and returns a list of list(indices).
-    clusterer: Clusterer
-        A callable object that takes in a dataset and returns an iterator of
-        numpy arrays which contain indices for clustered points.
-    dim: int
-        The highest dimension of the mapper complex to compute.
-    min_intersection: int
-        The minimum intersection required between clusters to make a simplex.
+    Args:
+        data: The high dimensional dataset
+        projection: The output of the lens/filter function on the data. Must have
+            the same number of elements as data.
+        cover_scheme: For cover generation. Should be a callable object that takes
+            a numpy array and returns a list of list(indices).
+        clusterer: A callable object that takes in a dataset and returns an
+            iterator of numpy arrays which contain indices for clustered points.
+        dim: The highest dimension of the mapper complex to compute.
+        min_intersection: The minimum intersection required between clusters to
+            make a simplex.
 
-    Returns
-    -------
-    MapperResult
-        An object containing:
-        - nodes: List of clusters where each cluster is a list of data indices.
-        - nerve: A complete list of simplices.
-        - cover: List of list(indices) corresponding to elements of the cover.
+    Returns:
+        The computational results of running mapper. A list of cluster, a
+        simplicial complex of those clusters, and a list of cover element
+        membership.
     """
 
     nodes = list()

--- a/packages/zen-mapper/src/zen_mapper/mapper.py
+++ b/packages/zen-mapper/src/zen_mapper/mapper.py
@@ -83,20 +83,14 @@ def compute_nerve(
 ) -> Komplex:
     """Helper function to find edges of the overlapping clusters.
 
-    Parameters
-    ----------
-    nodes:
-        A dictionary with entries `{node id}:{list of ids in node}`
-    dim:
-        An optional int, specifies the maximal dimension simplex. A value of
-        `None` puts no bound on the dimension. `dim = 0` returns only the nodes
-        of the complex. Default: 1
-    min_intersection:
-        How many points of intersection two covers should have to count as
-        connected. Default: 1
-    Returns
-    -------
-    simplices:
+    Args:
+        nodes: A dictionary with entries `{node id}:{list of ids in node}`
+        dim: An optional int, specifies the maximal dimension simplex. A value
+            of `None` puts no bound on the dimension. `dim = 0` returns only the
+            nodes of the complex. Default: 1
+        min_intersection: How many points of intersection two covers should
+            have to count as connected. Default: 1
+    Returns:
         Complete list of simplices
     """
     assert dim is None or dim >= 0, "dim must be at least 0"

--- a/packages/zen-mapper/src/zen_mapper/types.py
+++ b/packages/zen-mapper/src/zen_mapper/types.py
@@ -41,11 +41,9 @@ class Cover(Protocol):
 
     def __len__(self: Self) -> int:
         """
-        Returns the number of sets in the cover.
+        The number of sets in the cover.
 
-        Returns
-        -------
-        int
+        Returns:
             The number of sets in the cover.
         """
         ...
@@ -58,10 +56,8 @@ class Cover(Protocol):
         suitable for conversion to a NumPy array. The elements of these arrays
         are indices into the original data set
 
-        Yields
-        ------
-        npt.ArrayLike
-            An array-like object representing a set in the cover.
+        Yields:
+            A set in the cover
         """
         ...
 
@@ -77,18 +73,13 @@ class CoverScheme(Protocol):
     """
 
     def __call__(self: Self, data: np.ndarray) -> Cover:
-        """
-        Generates a `Cover` from the input data.
+        """Generate a `Cover` from the input data.
 
-        Parameters
-        ----------
-        data : np.ndarray
-            The input data
+        Args:
+            data: The input data
 
-        Returns
-        -------
-        Cover
-            A `Cover` object representing the generated cover of the data.
+        Returns:
+            The generated cover.
         """
         ...
 
@@ -101,26 +92,21 @@ class Simplex(tuple[int, ...]):
     implementation is essentially a python tuple with some convenience methods
     bolted on.
 
-    Parameters
-    ----------
-    vertices : Iterable[int]
-        Vertex ids for the simplex
+    Args:
+        vertices: Vertex ids for the simplex
 
-    Raises
-    ------
-    ValueError
-        If `vertices` contains repeated elements (a simplex must have unique vertices).
-    ValueError:
-        If `vertices` is empty (a simplex must have at least one vertex).
+    Raises:
+        ValueError: If `vertices` contains repeated elements (a simplex must
+            have unique vertices).
+        ValueError: If `vertices` is empty (a simplex must have at least one vertex).
 
-    Examples
-    --------
-    >>> s1 = Simplex([1, 0, 2])
-    >>> s1
-    (0, 1, 2)
-    >>> s2 = Simplex((5,))
-    >>> s2
-    (5,)
+    Examples:
+        >>> s1 = Simplex([1, 0, 2])
+        >>> s1
+        (0, 1, 2)
+        >>> s2 = Simplex((5,))
+        >>> s2
+        (5,)
     """
 
     def __new__(cls, vertices: Iterable[int]):
@@ -150,9 +136,7 @@ class Simplex(tuple[int, ...]):
         A simplex θ is a face of τ if and only if θ ⊆ τ. Note that as τ ⊆ τ
         that τ is a face of τ!
 
-        Yields
-        ------
-        simplex
+        Yields:
             a face of the simplex
         """
         for i in range(1, len(self) + 1):
@@ -175,54 +159,30 @@ class Komplex:
     class is optimized for construction, querying it is slow. If you seek to do
     much with it we recomend converting it to something else.
 
-    Parameters
-    ----------
-    simplices : Iterable[Simplex], optional
-        An initial collection of `Simplex` objects to populate the complex.
-        If `None`, the complex starts empty.
-
-    Methods
-    -------
-    add(simplex)
-        Adds a single simplex to the complex.
-    dim
-        Returns the highest dimension of any simplex in the complex.
-    __contains__(simplex)
-        Checks if a given simplex is present in the complex.
-    __getitem__(ind)
-        Yields all simplices of a specific dimension.
-    __iter__()
-        Iterates over all simplices in the complex.
-    vertices
-        Yields all unique vertices (0-simplices) in the complex.
+    Args:
+        simplices:
+            An initial collection of `Simplex` objects to populate the complex.
+            If `None`, the complex starts empty.
     """
 
     def __init__(self: Self, simplices: Iterable[Simplex] | None = None) -> None:
         self._simplices: set[Simplex] = set(simplices) if simplices else set()
 
     def add(self: Self, simplex: Simplex) -> None:
-        """
-        Adds a simplex to the simplicial complex.
+        """Adds a simplex to the simplicial complex.
 
-        Parameters
-        ----------
-        simplex : Simplex
-            The `Simplex` object to add to the complex.
+        Args:
+            simplex: The `Simplex` object to add to the complex.
         """
         self._simplices.add(simplex)
 
     @property
     def dim(self: Self) -> int:
         """
-        Returns the dimension of the simplicial complex.
+        The dimension of the simplicial complex.
 
         The dimension of the complex is the highest dimension of any simplex it
         contains. An empty complex has a dimension of 0.
-
-        Returns
-        -------
-        int
-            The dimension of the complex.
         """
         try:
             return max(simplex.dim for simplex in self._simplices)
@@ -236,14 +196,10 @@ class Komplex:
         """
         Checks if a given simplex is present in the complex.
 
-        Parameters
-        ----------
-        simplex : Simplex
-            The `Simplex` object to check for existence in the complex.
+        Args:
+            simplex: The `Simplex` to check for existence in the complex.
 
-        Returns
-        -------
-        bool
+        Returns:
             `True` if the simplex is in the complex, `False` otherwise.
         """
         return simplex in self._simplices
@@ -252,15 +208,11 @@ class Komplex:
         """
         Yields all simplices of a specific dimension from the complex.
 
-        Parameters
-        ----------
-        ind : int
-            The dimension of the simplices to retrieve (e.g., 0 for vertices,
-            1 for edges, 2 for triangles, etc.).
+        Args:
+            ind: The dimension of the simplices to retrieve (e.g., 0 for
+                vertices, 1 for edges, 2 for triangles, etc.).
 
-        Yields
-        ------
-        Simplex
+        Yields:
             A simplex of the specified dimension.
         """
         yield from (simplex for simplex in self._simplices if simplex.dim == ind)
@@ -269,23 +221,15 @@ class Komplex:
         """
         Iterates over all simplices contained within the complex.
 
-        Yields
-        ------
-        Simplex
+        Yields:
             Each simplex present in the complex.
         """
         yield from self._simplices
 
     @property
     def vertices(self: Self) -> Iterable[int]:
-        """
-        Yields all unique vertex identifiers (0-simplices) present in the complex.
-
-        Returns
-        -------
-        Iterable[int]
-            An iterable of integer vertex identifiers.
-        """
+        """All unique vertex identifiers (0-simplices) present
+        in the complex."""
         for simplex in self[0]:
             yield from simplex.vertices
 
@@ -297,36 +241,31 @@ class Clusterer(Protocol[H, M]):
     A `Clusterer` takes a dataset and a subset of its indices, returning a
     partition and associated metadata.
 
-    Methods
-    -------
-    __call__(data, elements)
-        Partition the specified elements of the dataset.
+    Note:
+        It is assumed that the returned partition satisfies the following properties:
 
-    Notes
-    -----
-    It is assumed that the returned partition satisfies the following properties:
+        1. **Disjointness**: No index from `elements` appears in more than one
+           partition array
+        2. **Exhaustiveness**: The union of all partition arrays exactly
+           equals the set of indices into `elements`
+        3. **Non-Empty**: No partition element is empty
 
-    1. **Disjointness**: No index from `elements` appears in more than one
-       partition array
-    2. **Exhaustiveness**: The union of all partition arrays exactly
-       equals the set of indices into `elements`
-    3. **Non-Empty**: No partition element is empty
+        For a dataset with 6 elements, `[[1, 2, 3], [0, 4], [5]]` is a valid
+        partition. While the following are considered invalid:
 
-    For a dataset with 6 elements, `[[1, 2, 3], [0, 4], [5]]` is a valid
-    partition. While the following are considered invalid:
+        - `[[1, 2, 3], [4], [5]]` (missing index 0)
+        - `[[1, 2, 3], [0, 4], [0, 5]]` (index 0 is duplicated)
+        - `[[1, 2, 3], [0, 4], [], [5]]` (there is an empty partition element)
 
-    - `[[1, 2, 3], [4], [5]]` (missing index 0)
-    - `[[1, 2, 3], [0, 4], [0, 5]]` (index 0 is duplicated)
-    - `[[1, 2, 3], [0, 4], [], [5]]` (there is an empty partition element)
+        If no meaningful metadata is produced by the clustering algorithm,
+        the second element of the returned tuple should be `None`.
 
-    If no meaningful metadata is produced by the clustering algorithm,
-    the second element of the returned tuple should be `None`.
+    See Also:
+        :doc:`/examples/custom_clusterer` : A narrated example of implementing
+        a clusterer
 
-    See Also
-    --------
-    :doc:`/examples/custom_clusterer` : A narrated example of implementing a clusterer
-
-    :func:`~zen_mapper.adapters.sk_learn` : An example clusterer defined in `zen_mapper`
+        :func:`~zen_mapper.adapters.sk_learn` : An example clusterer defined in
+        `zen_mapper`
     """
 
     def __call__(
@@ -336,34 +275,25 @@ class Clusterer(Protocol[H, M]):
     ) -> tuple[Collection[npt.ArrayLike], M]:
         """Partition a subset of the dataset into disjoint groups.
 
-        Parameters
-        ----------
-        data : H
-            The full dataset object.
-        elements : np.ndarray
-            An array of indices referencing the data points within `data`
+        Args:
+            data: The full dataset object.
+            elements: An array of indices referencing the data points within `data`
             that are to be clustered.
 
-        Returns
-        -------
-        partition : Collection[npt.ArrayLike]
-            A Collection of NumPy array-like things. Each array contains
-            indices into `elements`. The collection must form a partition of
-            `elements`.
-        metadata : M
-            Associated metadata produced by the clustering process. Returns
-            None if no meaningful metadata is generated.
+        Returns:
+            Returns a tuple `(partition, metadata)` where `partition` is a
+            collection of NumPy arrays which partitions the data and `metadata`
+            is arbitrary metadata defined by the clustering process. If no
+            meaningful metadata is produced `metadata` should be `None`.
 
-        See Also
-        --------
-        Clusterer : The protocol defining the expected behavior and
+        See Also:
+            Clusterer: The protocol defining the expected behavior and
             partitioning constraints.
 
-        Examples
-        --------
-        >>> # If elements is [0, 2, 4, 6, 8]
-        >>> # A valid return value might look like:
-        >>> ([np.array([1, 2]), np.array([0, 4]), np.array([3])], None)
+        Examples:
+            >>> # If elements is [0, 2, 4, 6, 8]
+            >>> # A valid return value might look like:
+            >>> ([np.array([1, 2]), np.array([0, 4]), np.array([3])], None)
         """
         ...
 
@@ -377,29 +307,23 @@ class MapperResult(Generic[M]):
     algorithm. It includes information about the Mapper complex, the
     constructed cover, and any metadata associated with the clusters of the
     complex.
-
-    Attributes
-    ----------
-    nodes : list[np.ndarray]
-        A list of NumPy arrays, where each array represents the points that
-        belong to a specific node in the Mapper graph. Each `np.ndarray`
-        corresponds to a cluster formed by the algorithm.
-    nerve : Komplex
-        A `Komplex` object representing the nerve of the cover. This `Komplex`
-        object defines the topological structure  of the Mapper graph, where
-        vertices correspond to the `nodes` in this result.
-    cover : list[list[int]]
-        Each inner list contains the indices of the original data points that
-        fall into a specific cover element. This provides a mapping from the
-        original dataset to the cover.
-    cluster_metadata : list[M | None]
-        A list of clustering metadata objects. The object `cluster_metadata[i]`
-        corresponds to whatever metadata the clusterer produced on cover
-        element `i`. If cover element `i` was empty this will
-        `cluster_metadata[i]` is `None`.
     """
 
     nodes: list[np.ndarray]
+    """ A list of NumPy arrays, where each array represents the points that
+    belong to a specific node in the Mapper graph. Each `np.ndarray`
+    corresponds to a cluster formed by the algorithm. """
     nerve: Komplex
+    """ A `Komplex` object representing the nerve of the cover. This `Komplex`
+    object defines the topological structure  of the Mapper graph, where
+    vertices correspond to the `nodes` in this result.
+    """
     cover: list[list[int]]
+    """ Each inner list contains the indices of the original data points that
+    fall into a specific cover element. This provides a mapping from the
+    original dataset to the cover. """
     cluster_metadata: list[M | None]
+    """ A list of clustering metadata objects. The object `cluster_metadata[i]`
+    corresponds to whatever metadata the clusterer produced on cover element
+    `i`. If cover element `i` was empty this will `cluster_metadata[i]` is
+    `None`. """

--- a/uv.lock
+++ b/uv.lock
@@ -1110,6 +1110,18 @@ wheels = [
 ]
 
 [[package]]
+name = "sphinx-autodoc-typehints"
+version = "3.11.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "sphinx" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d3/ac/99f66f906b15718687525fdf3601ca0b50d19c5e88d57cd4275a89355926/sphinx_autodoc_typehints-3.11.0.tar.gz", hash = "sha256:0112b322e2ebd993c0561af3c9e4615481b42dec199d665d6bacc875f3371e96", size = 82518, upload-time = "2026-06-11T18:48:34.225Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1b/55/7aaa2439e77cff66a6f348bb2d9894abf2b7b153595a5b974c5c277e9145/sphinx_autodoc_typehints-3.11.0-py3-none-any.whl", hash = "sha256:4ab73fe735c33168be3f34818034581155416e8e248d32ea1b604e90bea75223", size = 41610, upload-time = "2026-06-11T18:48:33.056Z" },
+]
+
+[[package]]
 name = "sphinx-design"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1246,7 +1258,7 @@ dev = [
 docs = [
     { name = "myst-parser" },
     { name = "sphinx" },
-    { name = "sphinx-autoapi" },
+    { name = "sphinx-autodoc-typehints" },
     { name = "sphinx-gallery" },
     { name = "sphinxcontrib-katex" },
 ]
@@ -1268,7 +1280,7 @@ dev = [
 docs = [
     { name = "myst-parser", specifier = ">=4.0.0" },
     { name = "sphinx", specifier = ">=8.1.3" },
-    { name = "sphinx-autoapi", specifier = ">=3.3.3" },
+    { name = "sphinx-autodoc-typehints", specifier = ">=3.11.0" },
     { name = "sphinx-gallery", specifier = ">=0.18.0" },
     { name = "sphinxcontrib-katex", specifier = ">=0.9.10" },
 ]


### PR DESCRIPTION
We use docstrings to automatically generate api documentation for zen mapper. We also use type annotations throughout the code. Right now this results in duplication of type information. Another minor annoyance is the linking to outside documentation is harder than it has to be. The type hint in the docstring is just text so sphinx has to be told `np.ndarray` is `numpy.ndarray` etc.

This change seeks to remove the type information from docstrings and infer it from the type annotations instead. This removes the duplication of type information and means sphinx can see that `np` points to numpy which helps with the automatic resolution of references.

To accomplish this two changes were made:

1. We use sphinx apidoc to generate the docs (documented in [adr-0007](https://github.com/zen-mapper/zen-mapper/blob/doc-update/packages/zen-mapper/docs/source/decisions/0007-use-sphinx-apidoc.md))
2. We now use google style doc strings (documented in [adr-0008](https://github.com/zen-mapper/zen-mapper/blob/doc-update/packages/zen-mapper/docs/source/decisions/0008-use-google-style-docstrings.md))

No substantial changes to the docs were attempted beyond that.

## Known Issues

I am not 100% satisfied with the result of this but at a certain point I can't justify anymore work fighting with sphinx. The biggest annoyance is that the return type is duplicated:

<img width="691" height="386" alt="image" src="https://github.com/user-attachments/assets/6ed7b129-6122-437e-8943-01cb012ab969" />

All my attempts to remedy this resulted in worse problems but I am open to ideas on how to fix it.